### PR TITLE
- try fix netflix_season

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -93,27 +93,22 @@
     </include>
 
     <!--Common-->
-    <include name="HiddenButton">
-        <posx>-2000</posx>
-        <posy>-2000</posy>
-        <width>1</width>
-        <height>1</height>
-        <label></label>
-		<texturenofocus></texturenofocus>
-        <texturefocus></texturefocus>
-    </include>
-	
-	<include name="HiddenObject">
-       <left>-3000</left>
+	<include name="HiddenOffset">
+		<left>-3000</left>
 		<top>-3000</top>
 		<width>1</width>
 		<height>1</height>
-		<texturefocus />
+	</include>
+	<include name="HiddenButton">
+		<include>HiddenOffset</include>
+        <label />
 		<texturenofocus />
-		<label></label>
-		<font></font>
-		<itemlayout/>
-		<focusedlayout/>
+        <texturefocus />
+    </include>
+	<include name="HiddenContainer">
+		<include>HiddenOffset</include>
+		<itemlayout height="10" width="10" />
+		<focusedlayout height="10" width="10" />
     </include>
 	
     <include name="DimensionsFullscreen">

--- a/1080i/IncludesBackgroundBuilding.xml
+++ b/1080i/IncludesBackgroundBuilding.xml
@@ -6,7 +6,7 @@
 		
 		<!-- HIDDEN ART -->
 		<control type ="group">
-			<include>HiddenObject</include>
+			<include>HiddenOffset</include>
 			<!-- COMMON FANART -->
 			<control type="image" id="99006">
 				<texture background="true">$VAR[fanartBackground]</texture>

--- a/1080i/IncludesDialogVideoInfo.xml
+++ b/1080i/IncludesDialogVideoInfo.xml
@@ -2289,8 +2289,6 @@
 								<left>695</left>
 								<include>AltRatingMovieInfo</include>
 								<animation effect="slide" end="0,270" center="auto" time="0" condition="String.IsEqual(ListItem.DBType,tvshow) + !Skin.String(mediaflagsstyle,disabled)">Conditional</animation>
-								<!--animation effect="slide" end="150,265" center="auto" time="0" condition="Skin.String(mediaflagsstyle,disabled)">Conditional</animation>
-								<!--animation effect="slide" end="350,265" center="auto" time="0" condition="String.IsEqual(ListItem.DBType,episode) + !Skin.String(mediaflagsstyle,disabled)">Conditional</animation-->
 								<visible>!Player.HasVideo</visible>
 							</control>
 							<!-- NEW dividing line -->
@@ -2677,7 +2675,7 @@
 
                 <!-- hidden my rating button -->
                 <control type="button" id="7">
-                    <include>HiddenObject</include>
+                    <include>HiddenContainer</include>
                 </control>
 
 				<!-- spotlight previewwindow section right -->

--- a/1080i/IncludesViews.xml
+++ b/1080i/IncludesViews.xml
@@ -29,7 +29,7 @@
 
         <!-- Thumb shape to be used -->
         <control type="label" id="5595">
-            <include>HiddenObject</include>
+            <include>HiddenOffset</include>
             <label>$VAR[ThumbShapeBasedOnSystem]</label>
         </control>
 

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -20,17 +20,10 @@
 		<include condition="!Skin.HasSetting(DisableNowPlayingBackground)">NowPlayingBackground</include>
 		
 		<control type="list" id="5055">
-			<visible>true</visible>
-			<include>HiddenObject</include>
+			<include>HiddenContainer</include>
 			<content limit="1">$VAR[container_content_getdbid_1]</content>
 		</control>
-		
-		<control type="button" id="878678">
-			<description>Let List  Gain Focus if id is uncleared</description>
-			<include>HiddenButton</include>
-			<onfocus>SetFocus(50)</onfocus>
-		</control>
-		
+			
 		<include>allViews</include>
 		
         <!--Sub Menu Tab Left-->

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -277,39 +277,39 @@
             <!--Control Tags-->
             <control type="grouplist">
                 <control type="label" id="5101">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[ListDetails]</label>
                 </control>
                 <control type="label" id="5201">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground1_label]</label>
                 </control>
                 <control type="label" id="5202">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground2_label]</label>
                 </control>
                 <control type="label" id="5203">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground3_label]</label>
                 </control>
                 <control type="label" id="5204">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground4_label]</label>
                 </control>
                 <control type="label" id="5301">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground1_value]</label>
                 </control>
                 <control type="label" id="5302">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground2_value]</label>
                 </control>
                 <control type="label" id="5303">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground3_value]</label>
                 </control>
                 <control type="label" id="5304">
-                    <include>HiddenButton</include>
+                    <include>HiddenOffset</include>
                     <label>$VAR[value_ground4_value]</label>
                 </control>
             </control>

--- a/1080i/View_529_NetflixSeasons.xml
+++ b/1080i/View_529_NetflixSeasons.xml
@@ -5,17 +5,15 @@
 		
 		<control type="group">
 			<visible>Control.IsVisible(529)</visible>
-			<visible>Integer.IsGreater(Container(529).NumItems,0)</visible>
-			<visible>Container.Content(seasons)</visible>
-			
-			<!-- <control type="button">
-				<top>300</top>
-				<height>300</height>
-				<label>Property Is TrailerPlaying [CR]not cleared via XML</label>
-				<visible>String.IsEqual(Window(Home).Property(TrailerPlaying),true)</visible>
+			<!-- String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) -->
+			<control type="list" id="529">
+				<description>need prop first load,clear bahaviour</description>
+				<include>HiddenContainer</include>
+				<onfocus>RunScript(script.embuary.helper,action=encode,string='"$INFO[Container.ShowTitle]"',prop=EncodedTitle)</onfocus>
+				<onfocus>SetFocus(529001)</onfocus>
+				<visible>Container.Content(seasons) + [Integer.IsEqual(Window(Home).Property(SkinHelper.ForcedView),529) | String.IsEmpty(Window(Home).Property(SkinHelper.ForcedView))]</visible>
+				<viewtype label="31902">Netflix Info</viewtype>
 			</control>
-			currently cleared trough skinhelperservice monitor
-			-->
 			
 			<control type="group">
 				<visible>!Skin.HasSetting(View529_DisableFanArt)</visible>
@@ -42,8 +40,8 @@
 			</control>
 			
 			<control type="grouplist" id="529000">
-				<visible>Container.Content(seasons)</visible>
 				<animation reversible="true" time="300" effect="fade" start="100" end="0" condition="String.IsEqual(Window(Home).Property(TrailerPlaying),true)">Conditional</animation>
+				<visible>String.IsEqual(Container.ViewMode,$LOCALIZE[31902])</visible>
 				<width>100%</width>
 				<height>100%</height>
 				<top>110</top>
@@ -61,7 +59,17 @@
 					<onleft>9000</onleft>
 					<height>1</height>
 					
-					<include content="weird_onback" />
+					<onleft condition="Control.IsVisible(529)">menu</onleft>
+					<onright condition="Control.IsVisible(529)">menu</onright>
+																	  
+					<onfocus condition="!Control.IsVisible(529)">SetFocus(50)</onfocus>
+					<onright condition="!Control.IsVisible(529)">SetFocus(50)</onright>
+					<onleft condition="!Control.IsVisible(529)">SetFocus(50)</onleft>
+					<onup condition="!Control.IsVisible(529)">SetFocus(50)</onup>
+					<ondown condition="!Control.IsVisible(529)">SetFocus(50)</ondown>
+					
+					<onback>SetFocus(50)</onback>
+					
 				</control>
 			
 				<control type="group" id="529002">
@@ -163,7 +171,7 @@
 						<orientation>horizontal</orientation>
 						<scrolltime tween="quadratic">400</scrolltime>
 						
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						
 						<itemlayout height="400" width="1040">
 							<control type="group">
@@ -215,7 +223,7 @@
 								</control>
 							</control>
 						</focusedlayout>
-						<content sortby="playcount" limit="1">$VAR[NextUp_SeasonLevel]</content>
+						<content sortby="playcount" limit="1">$VAR[view_529_NextUp_SeasonLevel]</content>
 					</control>
 				</control>
 				
@@ -239,11 +247,10 @@
 						<onup>529004</onup>
 						<ondown condition="Integer.IsGreater(Container(5290052).NumItems,0)">Control.SetFocus(5290052,0,absolute)</ondown>
 						<ondown condition="!Integer.IsGreater(Container(5290052).NumItems,0)">5290061</ondown>
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						<preloaditems>2</preloaditems>
 						<orientation>horizontal</orientation>
 						<scrolltime tween="quadratic">400</scrolltime>
-						
 						<itemlayout height="370" width="220">
 							<control type="group">
 								<height>310</height>
@@ -284,7 +291,7 @@
 								</control>
 							</control>
 						</focusedlayout>
-						<content sortby="season" target="videos">$INFO[Container.Folderpath]</content>
+						<content sortby="season" target="videos">$VAR[view_529_Content_Seasons]</content>
 					</control>
 					
 					<control type="image">
@@ -304,7 +311,7 @@
 						<onleft>9000</onleft>
 						<onup>5290051</onup>
 						<ondown>5290061</ondown>
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						<preloaditems>2</preloaditems>
 						<orientation>horizontal</orientation>
 						<scrolltime tween="quadratic" easing="in">400</scrolltime>
@@ -506,7 +513,7 @@
 								<label>$INFO[ListItem.Premiered]</label>
 							</control>
 						</focusedlayout>
-						<content sortby="year" target="videos">$INFO[Container(5290051).ListItem.Folderpath]</content>
+						<content sortby="year" target="videos">$VAR[view_529_Content_Episodes]</content>
 					</control>
 					
 					<control type="group">
@@ -571,7 +578,7 @@
 						<onup>5290052</onup>
 						<ondown condition="Control.IsVisible(5290062)">5290062</ondown>
 						<ondown condition="!Control.IsVisible(5290062)">5290071</ondown>
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						<top>170</top>
 						<left>40</left>
 						<width>1620</width>
@@ -612,9 +619,7 @@
 								</control>
 							</control>
 						</focusedlayout>
-						<content>plugin://script.skin.helper.service/?action=getcast&amp;tvshow=$INFO[ListItem.TVShowTitle]&amp;downloadthumbs=true</content>
-						<!--content>plugin://script.embuary.helper?info=getcast&amp;type=tvshow&amp;title='$ESCINFO[ListItem.TVShowTitle]'</content>
-						<!-- <content>plugin://script.embuary.helper?info=getcast&amp;type=tvshow&amp;dbid=$INFO[ListItem.DBID]&amp;idtype=season</content> -->
+						<content>$VAR[view_529_Content_Cast]</content>
 					</control>
 				
 					<include content="Special_Header">
@@ -631,7 +636,7 @@
 						<onleft>9000</onleft>
 						<onup>5290061</onup>
 						<ondown>5290071</ondown>
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						<preloaditems>2</preloaditems>
 						<orientation>horizontal</orientation>
 						<scrolltime tween="quadratic">400</scrolltime>
@@ -678,8 +683,7 @@
 								<thumb>$VAR[TVShowArt]</thumb>
 							</item>
 						</content>
-						<!--content target="videos" sortby="file" limit="3">$VAR[529_OnlineTrailerLookup]</content-->
-						<content target="videos" sortby="file" limit="3">plugin://plugin.video.youtube/search/?q=$VAR[529_OnlineTrailerLookup] ,$LOCALIZE[20364] ,$INFO[System.Language]</content>
+						<content target="videos" sortby="file" limit="3">$VAR[view_529_Content_YoutubeTrailer]</content>
 					</control>
 				</control>
 				
@@ -708,7 +712,7 @@
 						<onup condition="Control.IsVisible(5290063)">5290063</onup>
 						<onup condition="Control.IsVisible(5290062)">5290062</onup>
 						<onup condition="![Control.IsVisible(5290062) + Control.IsVisible(5290063)]">529006</onup>
-						<include content="weird_onback" />
+						<onback>SetFocus(50)</onback>
 						<ondown>529001</ondown>
 						<preloaditems>2</preloaditems>
 						<orientation>horizontal</orientation>
@@ -737,7 +741,7 @@
 								</control>
 							</control>
 						</focusedlayout>
-						<content target="videos">plugin://script.embuary.helper/?info=getsimilar&amp;type=tvshow&amp;dbid=$INFO[Container(5055).ListItem.dbid]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</content>
+						<content target="videos"></content>
 					</control>
 				</control>
 			</control>
@@ -789,15 +793,7 @@
 				<animation effect="slide" alignx="true" start="0,0" end="0,-310" tween="quadratic" time="400" condition="!Control.HasFocus(529001)">Conditional</animation>
 			</control>
 				
-			<control type="list" id="529">
-				<description>need prop first load,clear bahaviour</description>
-				<include>HiddenObject</include>
-				<onfocus>RunScript(script.embuary.helper,action=encode,string='"$INFO[Container.ShowTitle]"',prop=EncodedTitle)</onfocus>
-				<onfocus>SetFocus(529001)</onfocus>
-				<visible>Container.Content(seasons)</visible>
-				<visible>String.IsEqual(Window(Home).Property(SkinHelper.ForcedView),529) | String.IsEmpty(Window(Home).Property(SkinHelper.ForcedView))</visible>
-				<viewtype label="31902">Netflix Info</viewtype>
-			</control>
+			
 			
 			<control type="videowindow">
 				<visible>Player.HasVideo</visible>
@@ -985,11 +981,40 @@
 		<include condition="!Skin.HasSetting(UseHelveticaNeueNetflix_font)">font_Plot529</include>
 	</include>
 	
-	<variable name="NextUp_SeasonLevel">
-		<value condition="Container.Content(seasons) + String.EndsWith(Container.Folderpath,/)">$INFO[Container.Folderpath]-1/</value>
-		<value condition="Container.Content(seasons)">videodb://inprogresstvshows/-1/-1/&amp;?xsp=%7B%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22tvshow%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%5B%22$INFO[ListItem.TVShowTitle]%22%5D%7D%5D%7D%2C%22type%22%3A%22episodes%22%7D</value>
-	</variable>
 	
+	<variable name="view_529_NextUp_SeasonLevel">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + String.EndsWith(Container.Folderpath,/)">$INFO[Container.Folderpath]-1/</value>
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Window(home).Property(dbid))">videodb://inprogresstvshows/$INFO[Window(home).Property(dbid)]/-1/?tvshowid=$INFO[Window(home).Property(dbid)]</value>
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Window(home).Property(EncodedTitle))">videodb://inprogresstvshows/-1/-1/?xsp=%7B%22limit%22%3A1%2C%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22method%22%3A%22playcount%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22tvshow%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%5B%22$INFO[Window(home).Property(EncodedTitle)]%22%5D%7D%5D%7D%2C%22type%22%3A%22episodes%22%7D</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_NextUp_SeasonLevel_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_NextUp_SeasonLevel_is_called_but_IT_SHOULDNT</value>
+	</variable>
+	<variable name="view_529_Content_Seasons">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Container.Folderpath)">$INFO[Container.Folderpath]</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_Content_Seasons_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_Content_Seasons_is_called_but_IT_SHOULDNT</value>
+	</variable>
+	<variable name="view_529_Content_Episodes">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Container(5290051).ListItem.Folderpath)">$INFO[Container(5290051).ListItem.Folderpath]</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_Content_Episodes_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_Content_Episodes_is_called_but_IT_SHOULDNT</value>
+	</variable>
+	<variable name="view_529_Content_Cast">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Container(529).ListItem.TvShowDBID)">plugin://script.embuary.helper?info=getcast&amp;type=tvshow&amp;dbid=$INFO[Container(529)ListItem.TvShowDBID]</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_Content_Cast_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_Content_Cast_is_called_but_IT_SHOULDNT</value>
+	</variable>
+	<variable name="view_529_Content_YoutubeTrailer">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + [!$EXP[IsOfflineMode] + System.HasAddon(plugin.video.youtube) + !Skin.HasSetting(DONTEXIST_View_529_DisableOnlineTrailers)]">plugin://plugin.video.youtube/search/?q=$INFO[Container.FolderName]$INFO[System.Language, $LOCALIZE[20410] ,]</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_Content_YoutubeTrailer_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_Content_YoutubeTrailer_is_called_but_IT_SHOULDNT</value>
+	</variable>
+	<variable name="view_529_Content_Similiar">
+		<value condition="[String.IsEqual(Container.ViewMode,$LOCALIZE[31902]) + Container.Content(Seasons)] + !String.IsEmpty(Container(529).ListItem.TvShowDBID)">plugin://script.embuary.helper/?info=getsimilar&amp;type=tvshow&amp;dbid=$INFO[Container(529).ListItem.TvShowDBID]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.IsEqual(Container.ViewMode,$LOCALIZE[31902])">view_529_Content_Similiar_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
+		<value condition="Control.IsVisible(529)">view_529_Content_Similiar_is_called_but_IT_SHOULDNT</value>
+	</variable>
+			
 	<include name="DefArtwork">
 		<param name="visible" default="true" />
 		<param name="width" default="1344" />
@@ -1118,11 +1143,6 @@
 	!String.EndsWith(Network.LinkState,$LOCALIZE[15208]] not connected
 	!String.EndsWith(Network.DHCPAddress,$LOCALIZE[15208]] not connected
 	-->
-	<variable name="529_OnlineTrailerLookup">
-		<!--value condition="!$EXP[IsOfflineMode] + System.HasAddon(plugin.video.youtube)">plugin://plugin.video.youtube/search/?q=$INFO[Window(home).Property(EncodedTitle)]$INFO[System.Language, $LOCALIZE[20410] ,]</value-->
-		<value condition="!String.StartsWith(ListItem.FolderPath,plugin) + !String.IsEmpty(Window(home).Property(EncodedTitle))">$INFO[Window(home).Property(EncodedTitle)]</value>
-		<value condition="String.StartsWith(ListItem.FolderPath,plugin)">$INFO[ListItem.TVShowTitle]</value>
-	</variable>
 	<variable name="TVShowArt">
 		<value condition="!String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(tvshow.landscape)]</value>
 		<value condition="!String.IsEmpty(ListItem.Art(tvshow.fanart))">$INFO[ListItem.Art(tvshow.fanart)]</value>
@@ -1135,9 +1155,5 @@
 	<variable name="Season_Episodes">
 		<value condition="!String.IsEmpty(Container(5055).ListItem.Property(TotalEpisodes))">$VAR[Season_PluSing]$INFO[Container(5055).ListItem.Property(TotalSeasons), , | ]$INFO[Container(5055).ListItem.Property(TotalEpisodes),, $LOCALIZE[20360]]$INFO[Window(home).Property(SkinHelper.ListItem.Status), | ,]</value>
 		<value>$VAR[Season_PluSing]$INFO[Container(5290051).NumItems, ,]$INFO[Window(home).Property(SkinHelper.ListItem.Status), | ,]</value>
-	</variable>
-	<include name="weird_onback">
-		<onback>SetFocus(878678)</onback>
-	</include>
-						
+	</variable>					
 </includes>

--- a/1080i/script-skinshortcuts-includes.xml
+++ b/1080i/script-skinshortcuts-includes.xml
@@ -1,0 +1,5125 @@
+<includes>
+	<include name="skinshortcuts-mainmenu">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<label>$ADDON[script.skinshortcuts 32022]</label>
+			<label2>$ADDON[script.skinshortcuts 32022]</label2>
+			<icon>resource://resource.images.skinicons.wide/livetv.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.PvrBackground)]</thumb>
+			<property name="labelID">livetv</property>
+			<property name="defaultID">livetv</property>
+			<property name="widget">tvrecordings</property>
+			<property name="widgetName">$LOCALIZE[19017]</property>
+			<property name="widgetType">pvr</property>
+			<property name="widgetPath">plugin://script.skin.helper.widgets/?action=recordings&amp;mediatype=pvr&amp;reload=$INFO[Window(Home).Property(widgetreload2)]</property>
+			<property name="widgetTarget">pvr</property>
+			<property name="background">$INFO[Window(Home).Property(SkinHelper.PvrBackground)]</property>
+			<property name="backgroundName">571</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(TVChannels)</onclick>
+			<property name="path">ActivateWindow(TVChannels)</property>
+			<property name="list">TVChannels</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">livetv</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<label>$LOCALIZE[342]</label>
+			<label2>$LOCALIZE[342]</label2>
+			<icon>resource://resource.images.skinicons.wide/titan.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</thumb>
+			<property name="labelID">movies</property>
+			<property name="defaultID">movies</property>
+			<property name="widget">inprogressmovies</property>
+			<property name="widgetName">In progress movies</property>
+			<property name="widgetType">movies</property>
+			<property name="widgetPath">special://skin/playlists/video/InProgressMovies.xsp</property>
+			<property name="widgetTarget">videos</property>
+			<property name="background">$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</property>
+			<property name="backgroundName">$ADDON[script.skin.helper.service 32039]</property>
+			<property name="widget.1">recentmovies</property>
+			<property name="widgetTarget.1">videos</property>
+			<property name="widgetType.1">movies</property>
+			<property name="widgetPath.1">videodb://recentlyaddedmovies/</property>
+			<property name="widgetName.1">$LOCALIZE[20386]</property>
+			<property name="widget.99">randommovies</property>
+			<property name="widgetTarget.99">videos</property>
+			<property name="widgetType.99">movies</property>
+			<property name="widgetPath.99">special://skin/playlists/video/SpotlightMovies.xsp</property>
+			<property name="widgetName.99">Spotlight</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Videos,videodb://movies/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/titles/,return)</property>
+			<property name="list">videodb://movies/titles/</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">movies</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<label>$LOCALIZE[20343]</label>
+			<label2>$LOCALIZE[20343]</label2>
+			<icon>resource://resource.images.skinicons.wide/titan.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllTvShowsBackground)]</thumb>
+			<property name="labelID">tvshows</property>
+			<property name="defaultID">tvshows</property>
+			<property name="widget">inprogressepisodes</property>
+			<property name="widgetName">In progress episodes</property>
+			<property name="widgetType">episodes</property>
+			<property name="widgetPath">special://skin/playlists/video/InProgressEpisodes.xsp</property>
+			<property name="widgetTarget">videos</property>
+			<property name="background">$INFO[Window(Home).Property(SkinHelper.AllTvShowsBackground)]</property>
+			<property name="backgroundName">$ADDON[script.skin.helper.service 32043]</property>
+			<property name="widget.1">recentepisodes</property>
+			<property name="widgetTarget.1">videos</property>
+			<property name="widgetType.1">episodes</property>
+			<property name="widgetPath.1">videodb://recentlyaddedepisodes/</property>
+			<property name="widgetName.1">$LOCALIZE[20387]</property>
+			<property name="widget.99">randomtvshows</property>
+			<property name="widgetTarget.99">videos</property>
+			<property name="widgetType.99">tvshows</property>
+			<property name="widgetPath.99">special://skin/playlists/video/SpotlightTVshows.xsp</property>
+			<property name="widgetName.99">Spotlight</property>
+			<visible>Library.HasContent(TVShows)</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/titles/,return)</property>
+			<property name="list">videodb://tvshows/titles/</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">tvshows</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<label>$LOCALIZE[10502]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMusicBackground)]</thumb>
+			<property name="labelID">10502</property>
+			<property name="defaultID">10502</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Music,musicdb://,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://,return)</property>
+			<property name="list">musicdb://</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">num-10502</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<label>$LOCALIZE[20389]</label>
+			<label2>$LOCALIZE[20389]</label2>
+			<icon>resource://resource.images.skinbackgrounds.titanium/hover_my music.jpg</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMusicVideosBackground)]</thumb>
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">musicvideos</property>
+			<property name="widget">recentmusicvideos</property>
+			<property name="widgetName">$LOCALIZE[20390]</property>
+			<property name="widgetType">musicvideos</property>
+			<property name="widgetPath">videodb://recentlyaddedmusicvideos/</property>
+			<property name="widgetTarget">videos</property>
+			<property name="background">$INFO[Window(Home).Property(SkinHelper.AllMusicVideosBackground)]</property>
+			<property name="backgroundName">$ADDON[script.skin.helper.service 32047]</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">musicvideos</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<label>$LOCALIZE[12600]</label>
+			<label2>$LOCALIZE[12600]</label2>
+			<icon>resource://resource.images.skinicons.wide/weather.png</icon>
+			<thumb>$VAR[WeatherFanArtSingleImage_Current]</thumb>
+			<property name="labelID">weather</property>
+			<property name="defaultID">weather</property>
+			<property name="widget">weather</property>
+			<property name="widgetName">$LOCALIZE[8]</property>
+			<property name="widgetType">static</property>
+			<property name="widgetPath">$INCLUDE[WeatherWidget]</property>
+			<property name="widgetTarget">static</property>
+			<property name="background">$INFO[Skin.String(WeatherFanArtPack.path)]$INFO[Window(Weather).Property(Current.FanartCode)]$VAR[WeatherFanArtExtension]</property>
+			<visible>!String.IsEmpty(Weather.Plugin)</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Weather)</onclick>
+			<property name="path">ActivateWindow(Weather)</property>
+			<property name="list">Weather</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">weather</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">False</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<label>$LOCALIZE[31062]</label>
+			<label2>youtube</label2>
+			<icon>resource://resource.images.skinicons.wide/youtube.png</icon>
+			<thumb />
+			<property name="labelID">plugin.video.youtube</property>
+			<property name="defaultID">plugin.video.youtube</property>
+			<property name="background">resource://resource.images.skinbackgrounds.titanium/hover_extensions.jpg</property>
+			<property name="backgroundName">571</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Videos,plugin://plugin.video.youtube,return)</onclick>
+			<property name="path">ActivateWindow(Videos,plugin://plugin.video.youtube,return)</property>
+			<property name="list">plugin://plugin.video.youtube</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">plugin-video-youtube</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">False</property>
+		</item>
+		<item id="8">
+			<property name="id">$NUMBER[8]</property>
+			<label>$LOCALIZE[10002]</label>
+			<label2>$LOCALIZE[10002]</label2>
+			<icon>resource://resource.images.skinicons.wide/pictures.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.PicturesBackground)]</thumb>
+			<property name="labelID">pictures</property>
+			<property name="defaultID">pictures</property>
+			<property name="background">$INFO[Window(Home).Property(SkinHelper.PicturesBackground)]</property>
+			<property name="backgroundName">$ADDON[script.skin.helper.service 32046]</property>
+			<visible>!Skin.HasSetting(HomeMenuUsePlexforPictures)</visible>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(pictures,return)</onclick>
+			<property name="path">ActivateWindow(pictures,return)</property>
+			<property name="list">pictures</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">pictures</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">False</property>
+		</item>
+		<item id="9">
+			<property name="id">$NUMBER[9]</property>
+			<label>Games</label>
+			<label2>Games</label2>
+			<icon>resource://resource.images.skinicons.wide/games.png</icon>
+			<thumb />
+			<property name="labelID">games</property>
+			<property name="defaultID">games</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Games,return)</onclick>
+			<property name="path">ActivateWindow(Games,return)</property>
+			<property name="list">Games</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">games</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="10">
+			<property name="id">$NUMBER[10]</property>
+			<label>$LOCALIZE[10040]</label>
+			<label2>$LOCALIZE[10040]</label2>
+			<icon>resource://resource.images.skinicons.wide/addons.png</icon>
+			<thumb />
+			<property name="labelID">10040</property>
+			<property name="defaultID">10040</property>
+			<property name="background">resource://resource.images.skinbackgrounds.titanium/programs.jpg</property>
+			<property name="backgroundName">571</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Programs,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Programs,Addons,return)</property>
+			<property name="list">Addons</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">num-10040</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+		<item id="11">
+			<property name="id">$NUMBER[11]</property>
+			<label>$LOCALIZE[10025]</label>
+			<label2>$LOCALIZE[10025]</label2>
+			<icon>resource://resource.images.skinicons.wide/videos.png</icon>
+			<thumb />
+			<property name="labelID">10025</property>
+			<property name="defaultID">10025</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Videos,return)</onclick>
+			<property name="path">ActivateWindow(Videos,return)</property>
+			<property name="list">Videos</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">num-10025</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">False</property>
+		</item>
+		<item id="12">
+			<property name="id">$NUMBER[12]</property>
+			<label>$LOCALIZE[10004]</label>
+			<label2>$LOCALIZE[10004]</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">settings</property>
+			<property name="defaultID">settings</property>
+			<property name="widget">systeminfo</property>
+			<property name="widgetName">$LOCALIZE[130]</property>
+			<property name="widgetType">static</property>
+			<property name="widgetPath">$INCLUDE[SystemInfoWidget]</property>
+			<property name="widgetTarget">static</property>
+			<property name="background">resource://resource.images.skinbackgrounds.titanium/systeminfo.jpg</property>
+			<property name="backgroundName">571</property>
+			<onclick condition="![Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0) + ![String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]]">ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<onclick condition="[Skin.HasSetting(OpenSubMenuOnClick) + Integer.IsGreater(Container(4445).NumItems,0)] | [String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)]">SetFocus(4444,0)</onclick>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="submenuVisibility">settings</property>
+			<property name="group">mainmenu</property>
+			<property name="hasSubmenu">True</property>
+		</item>
+	</include>
+	<include />
+	<include name="skinshortcuts-submenu">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[22020]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">22020</property>
+			<property name="defaultID">22020</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVGuide)</onclick>
+			<property name="path">ActivateWindow(TVGuide)</property>
+			<property name="list">TVGuide</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19019]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19019</property>
+			<property name="defaultID">19019</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVChannels)</onclick>
+			<property name="path">ActivateWindow(TVChannels)</property>
+			<property name="list">TVChannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19163]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19163</property>
+			<property name="defaultID">19163</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVRecordings)</onclick>
+			<property name="path">ActivateWindow(TVRecordings)</property>
+			<property name="list">TVRecordings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19040]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19040</property>
+			<property name="defaultID">19040</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVTimers)</onclick>
+			<property name="path">ActivateWindow(TVTimers)</property>
+			<property name="list">TVTimers</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[137]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">137</property>
+			<property name="defaultID">137</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVSearch)</onclick>
+			<property name="path">ActivateWindow(TVSearch)</property>
+			<property name="list">TVSearch</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31050]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31050</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(10025,videodb://movies/titles/,return)</onclick>
+			<property name="path">ActivateWindow(10025,videodb://movies/titles/,return)</property>
+			<property name="list">videodb://movies/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20457]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20457</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(MovieSets)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/sets/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/sets/,return)</property>
+			<property name="list">videodb://movies/sets/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31127]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31127</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</property>
+			<property name="list">videodb://recentlyaddedmovies/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/genres/,return)</property>
+			<property name="list">videodb://movies/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20339]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20339</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/directors/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/directors/,return)</property>
+			<property name="list">videodb://movies/directors/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[562]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">562</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/years/,return)</property>
+			<property name="list">videodb://movies/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[574]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">574</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/countries/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/countries/,return)</property>
+			<property name="list">videodb://movies/countries/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="8">
+			<property name="id">$NUMBER[8]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31035]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31035</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/InProgressMovies.xsp</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="9">
+			<property name="id">$NUMBER[9]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[16101]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.UnwatchedMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">16101</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/UnwatchedMovies.xsp</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[31051]</label>
+			<label2>TV shows</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllTvShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">31051</property>
+			<property name="defaultID">369</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/titles/,return)</property>
+			<property name="list">videodb://tvshows/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[20387]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentEpisodesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20387</property>
+			<property name="defaultID">20387</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</property>
+			<property name="list">videodb://recentlyaddedepisodes/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[626]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">626</property>
+			<property name="defaultID">626</property>
+			<onclick>ActivateWindow(Videos,videodb://inprogresstvshows/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://inprogresstvshows/,return)</property>
+			<property name="list">videodb://inprogresstvshows/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>TV shows</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/genres/,return)</property>
+			<property name="list">videodb://tvshows/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[572]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/studios.png</icon>
+			<thumb />
+			<property name="labelID">572</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/studios/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/studios/,return)</property>
+			<property name="list">videodb://tvshows/studios/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[345]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/year.png</icon>
+			<thumb />
+			<property name="labelID">345</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/years/,return)</property>
+			<property name="list">videodb://tvshows/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[15100]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMusicBackground)]</thumb>
+			<property name="labelID">15100</property>
+			<property name="defaultID">15100</property>
+			<onclick>ActivateWindow(Music,musicdb://,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://,return)</property>
+			<property name="list">musicdb://</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[19021]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/radio.png</icon>
+			<thumb />
+			<property name="labelID">19021</property>
+			<property name="defaultID">19021</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(radiochannels,return)</onclick>
+			<property name="path">ActivateWindow(radiochannels,return)</property>
+			<property name="list">radiochannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[517]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">517</property>
+			<property name="defaultID">517</property>
+			<visible>[Library.HasContent(Music)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</property>
+			<property name="list">musicdb://recentlyplayedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[359]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">359</property>
+			<property name="defaultID">359</property>
+			<visible>[Library.HasContent(Music)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</property>
+			<property name="list">musicdb://recentlyaddedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[20389]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMusicVideosBackground)]</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(Music,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(Music,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10502)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">5</property>
+			<label>Music Videos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/,return)</property>
+			<property name="list">videodb://musicvideos/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Titles</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideotitles</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Genres</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideogenres</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/genres/,return)</property>
+			<property name="list">videodb://musicvideos/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/years/,return)</property>
+			<property name="list">videodb://musicvideos/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears--0</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/artists/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/artists/,return)</property>
+			<property name="list">videodb://musicvideos/artists/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoAlbums</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoalbums</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/albums/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/albums/,return)</property>
+			<property name="list">videodb://musicvideos/albums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">5</property>
+			<label>RecentlyAddedMusicVideos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">recentlyaddedmusicvideos</property>
+			<property name="defaultID">20390</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</property>
+			<property name="list">videodb://recentlyaddedmusicvideos/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),musicvideos)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">9</property>
+			<label>Kodi Games</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">kodigames</property>
+			<property name="defaultID">kodigames</property>
+			<onclick>ActivateWindow(Games,return)</onclick>
+			<property name="path">ActivateWindow(Games,return)</property>
+			<property name="list">Games</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">9</property>
+			<label>Advanced Emulator Launcher</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">plugin.program.advanced.emulator.launcher</property>
+			<property name="defaultID">plugin.program.advanced.emulator.launcher</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</onclick>
+			<property name="path">ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Favorites</label>
+			<label2>Favorites</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelfavorites</property>
+			<property name="defaultID">aelfavorites</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Genres</label>
+			<label2>Browse by genre</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelgenres</property>
+			<property name="defaultID">aelgenres</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Studios</label>
+			<label2>Browse by developer</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelstudios</property>
+			<property name="defaultID">aelstudios</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Titles</label>
+			<label2>Browse by titles</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aeltitles</property>
+			<property name="defaultID">aeltitles</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Years</label>
+			<label2>Browse by year</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelyears</property>
+			<property name="defaultID">aelyears</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[10001]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/programs.png</icon>
+			<thumb />
+			<property name="labelID">programs</property>
+			<property name="defaultID">programs</property>
+			<onclick>ActivateWindow(Programs,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Programs,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1037]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/videoaddons.png</icon>
+			<thumb />
+			<property name="labelID">1037</property>
+			<property name="defaultID">1037</property>
+			<onclick>ActivateWindow(Videos,addons,return)</onclick>
+			<property name="path">ActivateWindow(Videos,addons,return)</property>
+			<property name="list">addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(10502,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(10502,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1039]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/pictures.png</icon>
+			<thumb />
+			<property name="labelID">1039</property>
+			<property name="defaultID">1039</property>
+			<onclick>ActivateWindow(Pictures,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Pictures,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[20077]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">20077</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(SkinSettings)</onclick>
+			<property name="path">ActivateWindow(SkinSettings)</property>
+			<property name="list">SkinSettings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[10004]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">settings</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[7]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/filemanager.png</icon>
+			<thumb />
+			<property name="labelID">7</property>
+			<property name="defaultID">7</property>
+			<onclick>ActivateWindow(FileManager)</onclick>
+			<property name="path">ActivateWindow(FileManager)</property>
+			<property name="list">FileManager</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[14111]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">14111</property>
+			<property name="defaultID">14111</property>
+			<visible>[system.getbool(eventlog.enabled)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),settings)</visible>
+			<onclick>ActivateWindow(eventlog)</onclick>
+			<property name="path">ActivateWindow(eventlog)</property>
+			<property name="list">eventlog</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[20126]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/lock.png</icon>
+			<thumb />
+			<property name="labelID">20126</property>
+			<property name="defaultID">20126</property>
+			<visible>[[[System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)] + System.Loggedon] + [System.HasLoginScreen]] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),powermenu)</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>System.LogOff</onclick>
+			<property name="path">System.LogOff</property>
+			<property name="list">System.LogOff</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[5]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/settings1.png</icon>
+			<thumb />
+			<property name="labelID">5</property>
+			<property name="defaultID">5</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13009]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/exit1.png</icon>
+			<thumb />
+			<property name="labelID">13009</property>
+			<property name="defaultID">13009</property>
+			<visible>[System.ShowExitButton] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),powermenu)</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Quit()</onclick>
+			<property name="path">Quit()</property>
+			<property name="list">Quit()</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13016]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/shutdown1.png</icon>
+			<thumb />
+			<property name="labelID">13016</property>
+			<property name="defaultID">13016</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ShutDown</onclick>
+			<property name="path">ShutDown</property>
+			<property name="list">ShutDown</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13013]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/reboot1.png</icon>
+			<thumb />
+			<property name="labelID">13013</property>
+			<property name="defaultID">13013</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Reboot</onclick>
+			<property name="path">Reboot</property>
+			<property name="list">Reboot</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Container(300).ListItem.Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-livetv">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[22020]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">22020</property>
+			<property name="defaultID">22020</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(TVGuide)</onclick>
+			<property name="path">ActivateWindow(TVGuide)</property>
+			<property name="list">TVGuide</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19019]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19019</property>
+			<property name="defaultID">19019</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(TVChannels)</onclick>
+			<property name="path">ActivateWindow(TVChannels)</property>
+			<property name="list">TVChannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19163]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19163</property>
+			<property name="defaultID">19163</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(TVRecordings)</onclick>
+			<property name="path">ActivateWindow(TVRecordings)</property>
+			<property name="list">TVRecordings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19040]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19040</property>
+			<property name="defaultID">19040</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(TVTimers)</onclick>
+			<property name="path">ActivateWindow(TVTimers)</property>
+			<property name="list">TVTimers</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[137]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">137</property>
+			<property name="defaultID">137</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(TVSearch)</onclick>
+			<property name="path">ActivateWindow(TVSearch)</property>
+			<property name="list">TVSearch</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-livetv">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[22020]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">22020</property>
+			<property name="defaultID">22020</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVGuide)</onclick>
+			<property name="path">ActivateWindow(TVGuide)</property>
+			<property name="list">TVGuide</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19019]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19019</property>
+			<property name="defaultID">19019</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVChannels)</onclick>
+			<property name="path">ActivateWindow(TVChannels)</property>
+			<property name="list">TVChannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19163]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19163</property>
+			<property name="defaultID">19163</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVRecordings)</onclick>
+			<property name="path">ActivateWindow(TVRecordings)</property>
+			<property name="list">TVRecordings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[19040]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">19040</property>
+			<property name="defaultID">19040</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVTimers)</onclick>
+			<property name="path">ActivateWindow(TVTimers)</property>
+			<property name="list">TVTimers</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">1</property>
+			<label>$LOCALIZE[137]</label>
+			<label2>Live TV</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">137</property>
+			<property name="defaultID">137</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),livetv)</visible>
+			<onclick>ActivateWindow(TVSearch)</onclick>
+			<property name="path">ActivateWindow(TVSearch)</property>
+			<property name="list">TVSearch</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">livetv</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-movies">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31050]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31050</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick>ActivateWindow(10025,videodb://movies/titles/,return)</onclick>
+			<property name="path">ActivateWindow(10025,videodb://movies/titles/,return)</property>
+			<property name="list">videodb://movies/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20457]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20457</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(MovieSets)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/sets/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/sets/,return)</property>
+			<property name="list">videodb://movies/sets/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31127]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31127</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</property>
+			<property name="list">videodb://recentlyaddedmovies/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/genres/,return)</property>
+			<property name="list">videodb://movies/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20339]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20339</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/directors/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/directors/,return)</property>
+			<property name="list">videodb://movies/directors/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[562]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">562</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/years/,return)</property>
+			<property name="list">videodb://movies/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[574]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">574</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(Movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/countries/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/countries/,return)</property>
+			<property name="list">videodb://movies/countries/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="8">
+			<property name="id">$NUMBER[8]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31035]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31035</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/InProgressMovies.xsp</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="9">
+			<property name="id">$NUMBER[9]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[16101]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.UnwatchedMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">16101</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/UnwatchedMovies.xsp</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-movies">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31050]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31050</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(10025,videodb://movies/titles/,return)</onclick>
+			<property name="path">ActivateWindow(10025,videodb://movies/titles/,return)</property>
+			<property name="list">videodb://movies/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20457]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20457</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(MovieSets)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/sets/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/sets/,return)</property>
+			<property name="list">videodb://movies/sets/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31127]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31127</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmovies/,return)</property>
+			<property name="list">videodb://recentlyaddedmovies/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/genres/,return)</property>
+			<property name="list">videodb://movies/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[20339]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20339</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/directors/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/directors/,return)</property>
+			<property name="list">videodb://movies/directors/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[562]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">562</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/years/,return)</property>
+			<property name="list">videodb://movies/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[574]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">574</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(Movies)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<onclick>ActivateWindow(Videos,videodb://movies/countries/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://movies/countries/,return)</property>
+			<property name="list">videodb://movies/countries/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="8">
+			<property name="id">$NUMBER[8]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[31035]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">31035</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/InProgressMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/InProgressMovies.xsp</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="9">
+			<property name="id">$NUMBER[9]</property>
+			<property name="mainmenuid">2</property>
+			<label>$LOCALIZE[16101]</label>
+			<label2>Movies</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.UnwatchedMoviesBackground)]</icon>
+			<thumb />
+			<property name="labelID">16101</property>
+			<property name="defaultID">135</property>
+			<onclick>ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</onclick>
+			<property name="path">ActivateWindow(videos,special://skin/playlists/video/UnwatchedMovies.xsp,return)</property>
+			<property name="list">special://skin/playlists/video/UnwatchedMovies.xsp</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),movies)</visible>
+			<property name="group">movies</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-tvshows">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[31051]</label>
+			<label2>TV shows</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllTvShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">31051</property>
+			<property name="defaultID">369</property>
+			<visible>Library.HasContent(TVShows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/titles/,return)</property>
+			<property name="list">videodb://tvshows/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[20387]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentEpisodesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20387</property>
+			<property name="defaultID">20387</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</property>
+			<property name="list">videodb://recentlyaddedepisodes/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[626]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">626</property>
+			<property name="defaultID">626</property>
+			<onclick>ActivateWindow(Videos,videodb://inprogresstvshows/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://inprogresstvshows/,return)</property>
+			<property name="list">videodb://inprogresstvshows/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>TV shows</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(TVShows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/genres/,return)</property>
+			<property name="list">videodb://tvshows/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[572]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/studios.png</icon>
+			<thumb />
+			<property name="labelID">572</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(TVShows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/studios/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/studios/,return)</property>
+			<property name="list">videodb://tvshows/studios/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[345]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/year.png</icon>
+			<thumb />
+			<property name="labelID">345</property>
+			<property name="defaultID">135</property>
+			<visible>Library.HasContent(TVShows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/years/,return)</property>
+			<property name="list">videodb://tvshows/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-tvshows">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[31051]</label>
+			<label2>TV shows</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllTvShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">31051</property>
+			<property name="defaultID">369</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/titles/,return)</property>
+			<property name="list">videodb://tvshows/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[20387]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.RecentEpisodesBackground)]</icon>
+			<thumb />
+			<property name="labelID">20387</property>
+			<property name="defaultID">20387</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedepisodes/,return)</property>
+			<property name="list">videodb://recentlyaddedepisodes/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[626]</label>
+			<label2>Videos</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.InProgressShowsBackground)]</icon>
+			<thumb />
+			<property name="labelID">626</property>
+			<property name="defaultID">626</property>
+			<onclick>ActivateWindow(Videos,videodb://inprogresstvshows/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://inprogresstvshows/,return)</property>
+			<property name="list">videodb://inprogresstvshows/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[135]</label>
+			<label2>TV shows</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">135</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/genres/,return)</property>
+			<property name="list">videodb://tvshows/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[572]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/studios.png</icon>
+			<thumb />
+			<property name="labelID">572</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/studios/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/studios/,return)</property>
+			<property name="list">videodb://tvshows/studios/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">3</property>
+			<label>$LOCALIZE[345]</label>
+			<label2>TV shows</label2>
+			<icon>resource://resource.images.skinicons.wide/year.png</icon>
+			<thumb />
+			<property name="labelID">345</property>
+			<property name="defaultID">135</property>
+			<visible>[Library.HasContent(TVShows)] + String.IsEqual(Window(10000).Property(submenuVisibility),tvshows)</visible>
+			<onclick>ActivateWindow(Videos,videodb://tvshows/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://tvshows/years/,return)</property>
+			<property name="list">videodb://tvshows/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">tvshows</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-num-10502">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[15100]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMusicBackground)]</thumb>
+			<property name="labelID">15100</property>
+			<property name="defaultID">15100</property>
+			<onclick>ActivateWindow(Music,musicdb://,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://,return)</property>
+			<property name="list">musicdb://</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[19021]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/radio.png</icon>
+			<thumb />
+			<property name="labelID">19021</property>
+			<property name="defaultID">19021</property>
+			<visible>System.HasPVRAddon</visible>
+			<onclick>ActivateWindow(radiochannels,return)</onclick>
+			<property name="path">ActivateWindow(radiochannels,return)</property>
+			<property name="list">radiochannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[517]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">517</property>
+			<property name="defaultID">517</property>
+			<visible>Library.HasContent(Music)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</property>
+			<property name="list">musicdb://recentlyplayedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[359]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">359</property>
+			<property name="defaultID">359</property>
+			<visible>Library.HasContent(Music)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</property>
+			<property name="list">musicdb://recentlyaddedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[20389]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMusicVideosBackground)]</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(Music,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(Music,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-num-10502">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[15100]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb>$INFO[Window(Home).Property(SkinHelper.AllMusicBackground)]</thumb>
+			<property name="labelID">15100</property>
+			<property name="defaultID">15100</property>
+			<onclick>ActivateWindow(Music,musicdb://,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://,return)</property>
+			<property name="list">musicdb://</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[19021]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/radio.png</icon>
+			<thumb />
+			<property name="labelID">19021</property>
+			<property name="defaultID">19021</property>
+			<visible>[System.HasPVRAddon] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(radiochannels,return)</onclick>
+			<property name="path">ActivateWindow(radiochannels,return)</property>
+			<property name="list">radiochannels</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[517]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">517</property>
+			<property name="defaultID">517</property>
+			<visible>[Library.HasContent(Music)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyplayedalbums/,return)</property>
+			<property name="list">musicdb://recentlyplayedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[359]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">359</property>
+			<property name="defaultID">359</property>
+			<visible>[Library.HasContent(Music)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</onclick>
+			<property name="path">ActivateWindow(Music,musicdb://recentlyaddedalbums/,return)</property>
+			<property name="list">musicdb://recentlyaddedalbums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[20389]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>$INFO[Window(Home).Property(SkinHelper.AllMusicVideosBackground)]</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">4</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2>$LOCALIZE[10502]</label2>
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(Music,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(Music,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10502)</visible>
+			<property name="group">10502</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-musicvideos">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">5</property>
+			<label>Music Videos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/,return)</property>
+			<property name="list">videodb://musicvideos/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Titles</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideotitles</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Genres</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideogenres</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/genres/,return)</property>
+			<property name="list">videodb://musicvideos/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/years/,return)</property>
+			<property name="list">videodb://musicvideos/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears--0</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/artists/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/artists/,return)</property>
+			<property name="list">videodb://musicvideos/artists/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoAlbums</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoalbums</property>
+			<property name="defaultID">20389</property>
+			<visible>Library.HasContent(MusicVideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/albums/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/albums/,return)</property>
+			<property name="list">videodb://musicvideos/albums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">5</property>
+			<label>RecentlyAddedMusicVideos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">recentlyaddedmusicvideos</property>
+			<property name="defaultID">20390</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</property>
+			<property name="list">videodb://recentlyaddedmusicvideos/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-musicvideos">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">5</property>
+			<label>Music Videos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideos</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/,return)</property>
+			<property name="list">videodb://musicvideos/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Titles</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideotitles</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/titles/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/titles/,return)</property>
+			<property name="list">videodb://musicvideos/titles/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideo Genres</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideogenres</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/genres/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/genres/,return)</property>
+			<property name="list">videodb://musicvideos/genres/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/years/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/years/,return)</property>
+			<property name="list">videodb://musicvideos/years/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoYears</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoyears--0</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/artists/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/artists/,return)</property>
+			<property name="list">videodb://musicvideos/artists/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">5</property>
+			<label>MusicVideoAlbums</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">musicvideoalbums</property>
+			<property name="defaultID">20389</property>
+			<visible>[Library.HasContent(MusicVideos)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<onclick>ActivateWindow(Videos,videodb://musicvideos/albums/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://musicvideos/albums/,return)</property>
+			<property name="list">videodb://musicvideos/albums/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">5</property>
+			<label>RecentlyAddedMusicVideos</label>
+			<label2>MusicVideos</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">recentlyaddedmusicvideos</property>
+			<property name="defaultID">20390</property>
+			<onclick>ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</onclick>
+			<property name="path">ActivateWindow(Videos,videodb://recentlyaddedmusicvideos/,return)</property>
+			<property name="list">videodb://recentlyaddedmusicvideos/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),musicvideos)</visible>
+			<property name="group">musicvideos</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-weather">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-alt-weather">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-plugin-video-youtube">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-alt-plugin-video-youtube">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-pictures">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-alt-pictures">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-games">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">9</property>
+			<label>Kodi Games</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">kodigames</property>
+			<property name="defaultID">kodigames</property>
+			<onclick>ActivateWindow(Games,return)</onclick>
+			<property name="path">ActivateWindow(Games,return)</property>
+			<property name="list">Games</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">9</property>
+			<label>Advanced Emulator Launcher</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">plugin.program.advanced.emulator.launcher</property>
+			<property name="defaultID">plugin.program.advanced.emulator.launcher</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</onclick>
+			<property name="path">ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Favorites</label>
+			<label2>Favorites</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelfavorites</property>
+			<property name="defaultID">aelfavorites</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Genres</label>
+			<label2>Browse by genre</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelgenres</property>
+			<property name="defaultID">aelgenres</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Studios</label>
+			<label2>Browse by developer</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelstudios</property>
+			<property name="defaultID">aelstudios</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Titles</label>
+			<label2>Browse by titles</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aeltitles</property>
+			<property name="defaultID">aeltitles</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Years</label>
+			<label2>Browse by year</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelyears</property>
+			<property name="defaultID">aelyears</property>
+			<visible>System.HasAddon(plugin.program.advanced.emulator.launcher)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-games">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">9</property>
+			<label>Kodi Games</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">kodigames</property>
+			<property name="defaultID">kodigames</property>
+			<onclick>ActivateWindow(Games,return)</onclick>
+			<property name="path">ActivateWindow(Games,return)</property>
+			<property name="list">Games</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">9</property>
+			<label>Advanced Emulator Launcher</label>
+			<label2>Games</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">plugin.program.advanced.emulator.launcher</property>
+			<property name="defaultID">plugin.program.advanced.emulator.launcher</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</onclick>
+			<property name="path">ActivateWindow(Programs,plugin://plugin.program.advanced.emulator.launcher,return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Favorites</label>
+			<label2>Favorites</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelfavorites</property>
+			<property name="defaultID">aelfavorites</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_FAVOURITES</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Genres</label>
+			<label2>Browse by genre</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelgenres</property>
+			<property name="defaultID">aelgenres</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_genre</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Studios</label>
+			<label2>Browse by developer</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelstudios</property>
+			<property name="defaultID">aelstudios</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_developer</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="6">
+			<property name="id">$NUMBER[6]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Titles</label>
+			<label2>Browse by titles</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aeltitles</property>
+			<property name="defaultID">aeltitles</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_title</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="7">
+			<property name="id">$NUMBER[7]</property>
+			<property name="mainmenuid">9</property>
+			<label>AEL Years</label>
+			<label2>Browse by year</label2>
+			<icon>DefaultShortcut.png</icon>
+			<thumb />
+			<property name="labelID">aelyears</property>
+			<property name="defaultID">aelyears</property>
+			<visible>[System.HasAddon(plugin.program.advanced.emulator.launcher)] + String.IsEqual(Window(10000).Property(submenuVisibility),games)</visible>
+			<onclick>ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</onclick>
+			<property name="path">ActivateWindow(Programs,"plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year",return)</property>
+			<property name="list">plugin://plugin.program.advanced.emulator.launcher/?com=SHOW_VIRTUAL_CATEGORY&amp;catID=vcategory_year</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">games</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-num-10040">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[10001]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/programs.png</icon>
+			<thumb />
+			<property name="labelID">programs</property>
+			<property name="defaultID">programs</property>
+			<onclick>ActivateWindow(Programs,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Programs,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1037]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/videoaddons.png</icon>
+			<thumb />
+			<property name="labelID">1037</property>
+			<property name="defaultID">1037</property>
+			<onclick>ActivateWindow(Videos,addons,return)</onclick>
+			<property name="path">ActivateWindow(Videos,addons,return)</property>
+			<property name="list">addons</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(10502,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(10502,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1039]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/pictures.png</icon>
+			<thumb />
+			<property name="labelID">1039</property>
+			<property name="defaultID">1039</property>
+			<onclick>ActivateWindow(Pictures,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Pictures,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-num-10040">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[10001]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/programs.png</icon>
+			<thumb />
+			<property name="labelID">programs</property>
+			<property name="defaultID">programs</property>
+			<onclick>ActivateWindow(Programs,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Programs,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1037]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/videoaddons.png</icon>
+			<thumb />
+			<property name="labelID">1037</property>
+			<property name="defaultID">1037</property>
+			<onclick>ActivateWindow(Videos,addons,return)</onclick>
+			<property name="path">ActivateWindow(Videos,addons,return)</property>
+			<property name="list">addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1038]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/music.png</icon>
+			<thumb />
+			<property name="labelID">1038</property>
+			<property name="defaultID">1038</property>
+			<onclick>ActivateWindow(10502,addons://sources/audio/,return)</onclick>
+			<property name="path">ActivateWindow(10502,addons://sources/audio/,return)</property>
+			<property name="list">addons://sources/audio/</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">10</property>
+			<label>$LOCALIZE[1039]</label>
+			<label2 />
+			<icon>resource://resource.images.skinicons.wide/pictures.png</icon>
+			<thumb />
+			<property name="labelID">1039</property>
+			<property name="defaultID">1039</property>
+			<onclick>ActivateWindow(Pictures,Addons,return)</onclick>
+			<property name="path">ActivateWindow(Pictures,Addons,return)</property>
+			<property name="list">Addons</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),num-10040)</visible>
+			<property name="group">10040</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-num-10025">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-alt-num-10025">
+		<description>No items</description>
+	</include>
+	<include name="skinshortcuts-group-settings">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[20077]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">20077</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(SkinSettings)</onclick>
+			<property name="path">ActivateWindow(SkinSettings)</property>
+			<property name="list">SkinSettings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[10004]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">settings</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[7]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/filemanager.png</icon>
+			<thumb />
+			<property name="labelID">7</property>
+			<property name="defaultID">7</property>
+			<onclick>ActivateWindow(FileManager)</onclick>
+			<property name="path">ActivateWindow(FileManager)</property>
+			<property name="list">FileManager</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[14111]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">14111</property>
+			<property name="defaultID">14111</property>
+			<visible>system.getbool(eventlog.enabled)</visible>
+			<onclick>ActivateWindow(eventlog)</onclick>
+			<property name="path">ActivateWindow(eventlog)</property>
+			<property name="list">eventlog</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-settings">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[20077]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">20077</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(SkinSettings)</onclick>
+			<property name="path">ActivateWindow(SkinSettings)</property>
+			<property name="list">SkinSettings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[10004]</label>
+			<label2>Settings</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">settings</property>
+			<property name="defaultID">20077</property>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[7]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/filemanager.png</icon>
+			<thumb />
+			<property name="labelID">7</property>
+			<property name="defaultID">7</property>
+			<onclick>ActivateWindow(FileManager)</onclick>
+			<property name="path">ActivateWindow(FileManager)</property>
+			<property name="list">FileManager</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),settings)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">12</property>
+			<label>$LOCALIZE[14111]</label>
+			<label2>Common Shortcut</label2>
+			<icon>resource://resource.images.skinicons.wide/settings.png</icon>
+			<thumb />
+			<property name="labelID">14111</property>
+			<property name="defaultID">14111</property>
+			<visible>[system.getbool(eventlog.enabled)] + String.IsEqual(Window(10000).Property(submenuVisibility),settings)</visible>
+			<onclick>ActivateWindow(eventlog)</onclick>
+			<property name="path">ActivateWindow(eventlog)</property>
+			<property name="list">eventlog</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">settings</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-powermenu">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[20126]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/lock.png</icon>
+			<thumb />
+			<property name="labelID">20126</property>
+			<property name="defaultID">20126</property>
+			<visible>[[System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)] + System.Loggedon] + [System.HasLoginScreen]</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>System.LogOff</onclick>
+			<property name="path">System.LogOff</property>
+			<property name="list">System.LogOff</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[5]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/settings1.png</icon>
+			<thumb />
+			<property name="labelID">5</property>
+			<property name="defaultID">5</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13009]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/exit1.png</icon>
+			<thumb />
+			<property name="labelID">13009</property>
+			<property name="defaultID">13009</property>
+			<visible>System.ShowExitButton</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Quit()</onclick>
+			<property name="path">Quit()</property>
+			<property name="list">Quit()</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13016]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/shutdown1.png</icon>
+			<thumb />
+			<property name="labelID">13016</property>
+			<property name="defaultID">13016</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ShutDown</onclick>
+			<property name="path">ShutDown</property>
+			<property name="list">ShutDown</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13013]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/reboot1.png</icon>
+			<thumb />
+			<property name="labelID">13013</property>
+			<property name="defaultID">13013</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Reboot</onclick>
+			<property name="path">Reboot</property>
+			<property name="list">Reboot</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-group-alt-powermenu">
+		<item id="1">
+			<property name="id">$NUMBER[1]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[20126]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/lock.png</icon>
+			<thumb />
+			<property name="labelID">20126</property>
+			<property name="defaultID">20126</property>
+			<visible>[[[System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)] + System.Loggedon] + [System.HasLoginScreen]] + String.IsEqual(Window(10000).Property(submenuVisibility),powermenu)</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>System.LogOff</onclick>
+			<property name="path">System.LogOff</property>
+			<property name="list">System.LogOff</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="2">
+			<property name="id">$NUMBER[2]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[5]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/settings1.png</icon>
+			<thumb />
+			<property name="labelID">5</property>
+			<property name="defaultID">5</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ActivateWindow(Settings)</onclick>
+			<property name="path">ActivateWindow(Settings)</property>
+			<property name="list">Settings</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="3">
+			<property name="id">$NUMBER[3]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13009]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/exit1.png</icon>
+			<thumb />
+			<property name="labelID">13009</property>
+			<property name="defaultID">13009</property>
+			<visible>[System.ShowExitButton] + String.IsEqual(Window(10000).Property(submenuVisibility),powermenu)</visible>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Quit()</onclick>
+			<property name="path">Quit()</property>
+			<property name="list">Quit()</property>
+			<visible>String.IsEqual(System.ProfileName,Master user)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="4">
+			<property name="id">$NUMBER[4]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13016]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/shutdown1.png</icon>
+			<thumb />
+			<property name="labelID">13016</property>
+			<property name="defaultID">13016</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>ShutDown</onclick>
+			<property name="path">ShutDown</property>
+			<property name="list">ShutDown</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+		<item id="5">
+			<property name="id">$NUMBER[5]</property>
+			<property name="mainmenuid">13</property>
+			<label>$LOCALIZE[13013]</label>
+			<label2>Kodi Command</label2>
+			<icon>common/reboot1.png</icon>
+			<thumb />
+			<property name="labelID">13013</property>
+			<property name="defaultID">13013</property>
+			<onclick condition="Window.IsActive(DialogButtonMenu.xml)">Close</onclick>
+			<onclick>Reboot</onclick>
+			<property name="path">Reboot</property>
+			<property name="list">Reboot</property>
+			<visible>[String.IsEqual(System.ProfileName,Master user)] + String.IsEqual(Window(10000).Property(submenuVisibility),powermenu)</visible>
+			<property name="group">powermenu</property>
+			<property name="isSubmenu">True</property>
+		</item>
+	</include>
+	<include name="skinshortcuts-template-Widgets">
+		<include condition="String.IsEqual(System.ProfileName,Master user)">skinshortcuts-template-Widgets-Master user</include>
+	</include>
+	<include name="skinshortcuts-template-Widgets-Master user">
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="1" />
+			<param name="submenuid" value="livetv" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="false" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="1510" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="$LOCALIZE[19017]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1510" />
+			<param name="widgetName" value="$LOCALIZE[19017]" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="pvr" />
+			<param name="widgetPath" value="plugin://script.skin.helper.widgets/?action=recordings&amp;mediatype=pvr&amp;reload=$INFO[Window(Home).Property(widgetreload2)]" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-livetv,0) | !Skin.String(widgetvalue-livetv)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1520" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1520" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1530" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1540" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1550" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1560" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1570" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="1580" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="1580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="livetv" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-livetv,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="2" />
+			<param name="submenuid" value="movies" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="true" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="2510" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="In progress movies" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2510" />
+			<param name="widgetName" value="In progress movies" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="videos" />
+			<param name="widgetPath" value="special://skin/playlists/video/InProgressMovies.xsp" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-movies,0) | !Skin.String(widgetvalue-movies)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="2520" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="$LOCALIZE[20386]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2520" />
+			<param name="widgetName" value="$LOCALIZE[20386]" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="videos" />
+			<param name="widgetPath" value="videodb://recentlyaddedmovies/" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2530" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2540" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2550" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2560" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2570" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="2580" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="2580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="movies" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-movies,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="3" />
+			<param name="submenuid" value="tvshows" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="true" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="3510" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="In progress episodes" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3510" />
+			<param name="widgetName" value="In progress episodes" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="videos" />
+			<param name="widgetPath" value="special://skin/playlists/video/InProgressEpisodes.xsp" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-tvshows,0) | !Skin.String(widgetvalue-tvshows)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="3520" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="$LOCALIZE[20387]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3520" />
+			<param name="widgetName" value="$LOCALIZE[20387]" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="videos" />
+			<param name="widgetPath" value="videodb://recentlyaddedepisodes/" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3530" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3540" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3550" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3560" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3570" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="3580" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="3580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="tvshows" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-tvshows,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="5" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="false" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="5510" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="$LOCALIZE[20390]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5510" />
+			<param name="widgetName" value="$LOCALIZE[20390]" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="videos" />
+			<param name="widgetPath" value="videodb://recentlyaddedmusicvideos/" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-musicvideos,0) | !Skin.String(widgetvalue-musicvideos)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5520" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5520" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5530" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5540" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5550" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5560" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5570" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="5580" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="5580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="musicvideos" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-musicvideos,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="6" />
+			<param name="submenuid" value="weather" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="false" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="6510" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="$LOCALIZE[8]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="weather" />
+			<param name="widgetid" value="6510" />
+			<param name="widgetName" value="$LOCALIZE[8]" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="static" />
+			<param name="widgetPath" value="$INCLUDE[WeatherWidget]" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-weather,0) | !Skin.String(widgetvalue-weather)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6520" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6520" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6530" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6540" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6550" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6560" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6570" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="6580" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="6580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="weather" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-weather,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_single" condition="!Skin.String(HomeLayout,win10) + ![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + true">
+			<param name="mainmenuid" value="12" />
+			<param name="submenuid" value="settings" />
+			<param name="hasWidget0" value="true" />
+			<param name="hasWidget1" value="false" />
+			<param name="hasWidget2" value="false" />
+			<param name="hasWidget3" value="false" />
+			<param name="hasWidget4" value="false" />
+			<param name="hasWidget5" value="false" />
+			<param name="hasWidget6" value="false" />
+			<param name="hasWidget7" value="false" />
+			<param name="widgetStyle1" value="default" />
+			<param name="widgetStyle2" value="default" />
+			<param name="widgetStyle3" value="default" />
+			<param name="widgetStyle4" value="default" />
+			<param name="widgetStyle5" value="default" />
+			<param name="widgetStyle6" value="default" />
+			<param name="widgetStyle7" value="default" />
+			<param name="widgetStyle8" value="default" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + true">
+			<param name="widgetid" value="12510" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="$LOCALIZE[130]" />
+		</include>
+		<include content="widget_base" condition="true">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="systeminfo" />
+			<param name="widgetid" value="12510" />
+			<param name="widgetName" value="$LOCALIZE[130]" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="static" />
+			<param name="widgetPath" value="$INCLUDE[SystemInfoWidget]" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + [Skin.String(widgetvalue-settings,0) | !Skin.String(widgetvalue-settings)]]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12520" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12520" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,1)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12530" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12530" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,2)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12540" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12540" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,3)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12550" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12550" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,4)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12560" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12560" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,5)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12570" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12570" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,6)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+		<include content="widget_header_multi" condition="!Skin.String(HomeLayout,win10) + true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)] + false">
+			<param name="widgetid" value="12580" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetName" value="" />
+		</include>
+		<include content="widget_base" condition="false">
+			<param name="containerType" value="panel" />
+			<param name="contentStyle" value="normal" />
+			<param name="widgetid" value="12580" />
+			<param name="widgetName" value="" />
+			<param name="submenuid" value="settings" />
+			<param name="widgetTags" value="" />
+			<param name="widgetTarget" value="" />
+			<param name="widgetPath" value="" />
+			<param name="widgetStyle" value="widget_layout_default" />
+			<param name="widgetInfoPanel" value="top" />
+			<param name="visibility" value="Skin.String(HomeLayout,win10) | [true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] | [![true + [String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix)]] + Skin.String(widgetvalue-settings,7)]" />
+			<param name="multiRows" value="false + String.Contains(Skin.String(HomeLayout),ver)" />
+		</include>
+	</include>
+	<include name="skinshortcuts-template-spotlightwidget">
+		<include condition="String.IsEqual(System.ProfileName,Master user)">skinshortcuts-template-spotlightwidget-Master user</include>
+	</include>
+	<include name="skinshortcuts-template-spotlightwidget-Master user">
+		<control type="panel" id="1508">
+			<visible>String.IsEqual(Container(300).ListItem.Property(submenuVisibility),movies)</visible>
+			<include>EnhancedHomeSpotLightWidgetLayout</include>
+			<content target="videos">special://skin/playlists/video/SpotlightMovies.xsp</content>
+		</control>
+		<control type="panel" id="1508">
+			<visible>String.IsEqual(Container(300).ListItem.Property(submenuVisibility),tvshows)</visible>
+			<include>EnhancedHomeSpotLightWidgetLayout</include>
+			<content target="videos">special://skin/playlists/video/SpotlightTVshows.xsp</content>
+		</control>
+	</include>
+	<variable name="1510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>plugin://script.skin.helper.widgets/?action=recordings&amp;mediatype=pvr&amp;reload=$INFO[Window(Home).Property(widgetreload2)]</value>
+	</variable>
+	<variable name="widgetinfolabel-1510">
+		<value condition="String.Contains(Container(1510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1510).ListItem.label] $INFO[Container(1510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Title) + String.Contains(Container(1510).ListItem.FolderPath, pvr://)">$INFO[Container(1510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Season) + !String.IsEmpty(Container(1510).ListItem.Episode) + !String.Contains(Container(1510).ListItem.TvShowTitle,Container(1510).ListItem.Title)">[UPPERCASE]S$INFO[Container(1510).ListItem.Season]E$INFO[Container(1510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Title)">$INFO[Container(1510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Label)">$INFO[Container(1510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1510">
+		<value condition="!String.IsEmpty(Container(1510).ListItem.TvShowTitle) + !String.IsEmpty(Container(1510).ListItem.Genre)">$INFO[Container(1510).ListItem.TvShowTitle,, • ]$INFO[Container(1510).ListItem.Year,, • ]$INFO[Container(1510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.TvShowTitle)">$INFO[Container(1510).ListItem.TvShowTitle,, • ]$INFO[Container(1510).ListItem.Premiered,, • ]$INFO[Container(1510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Year)">$INFO[Container(1510).ListItem.Year,, • ]$INFO[Container(1510).ListItem.Duration,,min. • ]$INFO[Container(1510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Artist) + !String.IsEmpty(Container(1510).ListItem.Album)">$INFO[Container(1510).ListItem.Artist,, • ]$INFO[Container(1510).ListItem.Album,, • ]$INFO[Container(1510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.Property(StartTime))">$INFO[Container(1510).ListItem.Property(ChannelName),, • ]$INFO[Container(1510).ListItem.Property(StartTime),, - ]$INFO[Container(1510).ListItem.Property(EndTime),, • ]$INFO[Container(1510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1510).ListItem.StartTime)">$INFO[Container(1510).ListItem.ChannelName,, • ]$INFO[Container(1510).ListItem.StartTime,, - ]$INFO[Container(1510).ListItem.EndTime,, • ]$INFO[Container(1510).ListItem.Genre]</value>
+	</variable>
+	<variable name="1520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1520">
+		<value condition="String.Contains(Container(1520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1520).ListItem.label] $INFO[Container(1520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Title) + String.Contains(Container(1520).ListItem.FolderPath, pvr://)">$INFO[Container(1520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Season) + !String.IsEmpty(Container(1520).ListItem.Episode) + !String.Contains(Container(1520).ListItem.TvShowTitle,Container(1520).ListItem.Title)">[UPPERCASE]S$INFO[Container(1520).ListItem.Season]E$INFO[Container(1520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Title)">$INFO[Container(1520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Label)">$INFO[Container(1520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1520">
+		<value condition="!String.IsEmpty(Container(1520).ListItem.TvShowTitle) + !String.IsEmpty(Container(1520).ListItem.Genre)">$INFO[Container(1520).ListItem.TvShowTitle,, • ]$INFO[Container(1520).ListItem.Year,, • ]$INFO[Container(1520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.TvShowTitle)">$INFO[Container(1520).ListItem.TvShowTitle,, • ]$INFO[Container(1520).ListItem.Premiered,, • ]$INFO[Container(1520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Year)">$INFO[Container(1520).ListItem.Year,, • ]$INFO[Container(1520).ListItem.Duration,,min. • ]$INFO[Container(1520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Artist) + !String.IsEmpty(Container(1520).ListItem.Album)">$INFO[Container(1520).ListItem.Artist,, • ]$INFO[Container(1520).ListItem.Album,, • ]$INFO[Container(1520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.Property(StartTime))">$INFO[Container(1520).ListItem.Property(ChannelName),, • ]$INFO[Container(1520).ListItem.Property(StartTime),, - ]$INFO[Container(1520).ListItem.Property(EndTime),, • ]$INFO[Container(1520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1520).ListItem.StartTime)">$INFO[Container(1520).ListItem.ChannelName,, • ]$INFO[Container(1520).ListItem.StartTime,, - ]$INFO[Container(1520).ListItem.EndTime,, • ]$INFO[Container(1520).ListItem.Genre]</value>
+	</variable>
+	<variable name="1530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1530">
+		<value condition="String.Contains(Container(1530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1530).ListItem.label] $INFO[Container(1530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Title) + String.Contains(Container(1530).ListItem.FolderPath, pvr://)">$INFO[Container(1530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Season) + !String.IsEmpty(Container(1530).ListItem.Episode) + !String.Contains(Container(1530).ListItem.TvShowTitle,Container(1530).ListItem.Title)">[UPPERCASE]S$INFO[Container(1530).ListItem.Season]E$INFO[Container(1530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Title)">$INFO[Container(1530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Label)">$INFO[Container(1530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1530">
+		<value condition="!String.IsEmpty(Container(1530).ListItem.TvShowTitle) + !String.IsEmpty(Container(1530).ListItem.Genre)">$INFO[Container(1530).ListItem.TvShowTitle,, • ]$INFO[Container(1530).ListItem.Year,, • ]$INFO[Container(1530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.TvShowTitle)">$INFO[Container(1530).ListItem.TvShowTitle,, • ]$INFO[Container(1530).ListItem.Premiered,, • ]$INFO[Container(1530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Year)">$INFO[Container(1530).ListItem.Year,, • ]$INFO[Container(1530).ListItem.Duration,,min. • ]$INFO[Container(1530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Artist) + !String.IsEmpty(Container(1530).ListItem.Album)">$INFO[Container(1530).ListItem.Artist,, • ]$INFO[Container(1530).ListItem.Album,, • ]$INFO[Container(1530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.Property(StartTime))">$INFO[Container(1530).ListItem.Property(ChannelName),, • ]$INFO[Container(1530).ListItem.Property(StartTime),, - ]$INFO[Container(1530).ListItem.Property(EndTime),, • ]$INFO[Container(1530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1530).ListItem.StartTime)">$INFO[Container(1530).ListItem.ChannelName,, • ]$INFO[Container(1530).ListItem.StartTime,, - ]$INFO[Container(1530).ListItem.EndTime,, • ]$INFO[Container(1530).ListItem.Genre]</value>
+	</variable>
+	<variable name="1540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1540">
+		<value condition="String.Contains(Container(1540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1540).ListItem.label] $INFO[Container(1540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Title) + String.Contains(Container(1540).ListItem.FolderPath, pvr://)">$INFO[Container(1540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Season) + !String.IsEmpty(Container(1540).ListItem.Episode) + !String.Contains(Container(1540).ListItem.TvShowTitle,Container(1540).ListItem.Title)">[UPPERCASE]S$INFO[Container(1540).ListItem.Season]E$INFO[Container(1540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Title)">$INFO[Container(1540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Label)">$INFO[Container(1540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1540">
+		<value condition="!String.IsEmpty(Container(1540).ListItem.TvShowTitle) + !String.IsEmpty(Container(1540).ListItem.Genre)">$INFO[Container(1540).ListItem.TvShowTitle,, • ]$INFO[Container(1540).ListItem.Year,, • ]$INFO[Container(1540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.TvShowTitle)">$INFO[Container(1540).ListItem.TvShowTitle,, • ]$INFO[Container(1540).ListItem.Premiered,, • ]$INFO[Container(1540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Year)">$INFO[Container(1540).ListItem.Year,, • ]$INFO[Container(1540).ListItem.Duration,,min. • ]$INFO[Container(1540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Artist) + !String.IsEmpty(Container(1540).ListItem.Album)">$INFO[Container(1540).ListItem.Artist,, • ]$INFO[Container(1540).ListItem.Album,, • ]$INFO[Container(1540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.Property(StartTime))">$INFO[Container(1540).ListItem.Property(ChannelName),, • ]$INFO[Container(1540).ListItem.Property(StartTime),, - ]$INFO[Container(1540).ListItem.Property(EndTime),, • ]$INFO[Container(1540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1540).ListItem.StartTime)">$INFO[Container(1540).ListItem.ChannelName,, • ]$INFO[Container(1540).ListItem.StartTime,, - ]$INFO[Container(1540).ListItem.EndTime,, • ]$INFO[Container(1540).ListItem.Genre]</value>
+	</variable>
+	<variable name="1550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1550">
+		<value condition="String.Contains(Container(1550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1550).ListItem.label] $INFO[Container(1550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Title) + String.Contains(Container(1550).ListItem.FolderPath, pvr://)">$INFO[Container(1550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Season) + !String.IsEmpty(Container(1550).ListItem.Episode) + !String.Contains(Container(1550).ListItem.TvShowTitle,Container(1550).ListItem.Title)">[UPPERCASE]S$INFO[Container(1550).ListItem.Season]E$INFO[Container(1550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Title)">$INFO[Container(1550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Label)">$INFO[Container(1550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1550">
+		<value condition="!String.IsEmpty(Container(1550).ListItem.TvShowTitle) + !String.IsEmpty(Container(1550).ListItem.Genre)">$INFO[Container(1550).ListItem.TvShowTitle,, • ]$INFO[Container(1550).ListItem.Year,, • ]$INFO[Container(1550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.TvShowTitle)">$INFO[Container(1550).ListItem.TvShowTitle,, • ]$INFO[Container(1550).ListItem.Premiered,, • ]$INFO[Container(1550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Year)">$INFO[Container(1550).ListItem.Year,, • ]$INFO[Container(1550).ListItem.Duration,,min. • ]$INFO[Container(1550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Artist) + !String.IsEmpty(Container(1550).ListItem.Album)">$INFO[Container(1550).ListItem.Artist,, • ]$INFO[Container(1550).ListItem.Album,, • ]$INFO[Container(1550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.Property(StartTime))">$INFO[Container(1550).ListItem.Property(ChannelName),, • ]$INFO[Container(1550).ListItem.Property(StartTime),, - ]$INFO[Container(1550).ListItem.Property(EndTime),, • ]$INFO[Container(1550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1550).ListItem.StartTime)">$INFO[Container(1550).ListItem.ChannelName,, • ]$INFO[Container(1550).ListItem.StartTime,, - ]$INFO[Container(1550).ListItem.EndTime,, • ]$INFO[Container(1550).ListItem.Genre]</value>
+	</variable>
+	<variable name="1560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1560">
+		<value condition="String.Contains(Container(1560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1560).ListItem.label] $INFO[Container(1560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Title) + String.Contains(Container(1560).ListItem.FolderPath, pvr://)">$INFO[Container(1560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Season) + !String.IsEmpty(Container(1560).ListItem.Episode) + !String.Contains(Container(1560).ListItem.TvShowTitle,Container(1560).ListItem.Title)">[UPPERCASE]S$INFO[Container(1560).ListItem.Season]E$INFO[Container(1560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Title)">$INFO[Container(1560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Label)">$INFO[Container(1560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1560">
+		<value condition="!String.IsEmpty(Container(1560).ListItem.TvShowTitle) + !String.IsEmpty(Container(1560).ListItem.Genre)">$INFO[Container(1560).ListItem.TvShowTitle,, • ]$INFO[Container(1560).ListItem.Year,, • ]$INFO[Container(1560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.TvShowTitle)">$INFO[Container(1560).ListItem.TvShowTitle,, • ]$INFO[Container(1560).ListItem.Premiered,, • ]$INFO[Container(1560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Year)">$INFO[Container(1560).ListItem.Year,, • ]$INFO[Container(1560).ListItem.Duration,,min. • ]$INFO[Container(1560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Artist) + !String.IsEmpty(Container(1560).ListItem.Album)">$INFO[Container(1560).ListItem.Artist,, • ]$INFO[Container(1560).ListItem.Album,, • ]$INFO[Container(1560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.Property(StartTime))">$INFO[Container(1560).ListItem.Property(ChannelName),, • ]$INFO[Container(1560).ListItem.Property(StartTime),, - ]$INFO[Container(1560).ListItem.Property(EndTime),, • ]$INFO[Container(1560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1560).ListItem.StartTime)">$INFO[Container(1560).ListItem.ChannelName,, • ]$INFO[Container(1560).ListItem.StartTime,, - ]$INFO[Container(1560).ListItem.EndTime,, • ]$INFO[Container(1560).ListItem.Genre]</value>
+	</variable>
+	<variable name="1570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1570">
+		<value condition="String.Contains(Container(1570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1570).ListItem.label] $INFO[Container(1570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Title) + String.Contains(Container(1570).ListItem.FolderPath, pvr://)">$INFO[Container(1570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Season) + !String.IsEmpty(Container(1570).ListItem.Episode) + !String.Contains(Container(1570).ListItem.TvShowTitle,Container(1570).ListItem.Title)">[UPPERCASE]S$INFO[Container(1570).ListItem.Season]E$INFO[Container(1570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Title)">$INFO[Container(1570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Label)">$INFO[Container(1570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1570">
+		<value condition="!String.IsEmpty(Container(1570).ListItem.TvShowTitle) + !String.IsEmpty(Container(1570).ListItem.Genre)">$INFO[Container(1570).ListItem.TvShowTitle,, • ]$INFO[Container(1570).ListItem.Year,, • ]$INFO[Container(1570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.TvShowTitle)">$INFO[Container(1570).ListItem.TvShowTitle,, • ]$INFO[Container(1570).ListItem.Premiered,, • ]$INFO[Container(1570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Year)">$INFO[Container(1570).ListItem.Year,, • ]$INFO[Container(1570).ListItem.Duration,,min. • ]$INFO[Container(1570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Artist) + !String.IsEmpty(Container(1570).ListItem.Album)">$INFO[Container(1570).ListItem.Artist,, • ]$INFO[Container(1570).ListItem.Album,, • ]$INFO[Container(1570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.Property(StartTime))">$INFO[Container(1570).ListItem.Property(ChannelName),, • ]$INFO[Container(1570).ListItem.Property(StartTime),, - ]$INFO[Container(1570).ListItem.Property(EndTime),, • ]$INFO[Container(1570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1570).ListItem.StartTime)">$INFO[Container(1570).ListItem.ChannelName,, • ]$INFO[Container(1570).ListItem.StartTime,, - ]$INFO[Container(1570).ListItem.EndTime,, • ]$INFO[Container(1570).ListItem.Genre]</value>
+	</variable>
+	<variable name="1580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-1580">
+		<value condition="String.Contains(Container(1580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(1580).ListItem.label] $INFO[Container(1580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Title) + String.Contains(Container(1580).ListItem.FolderPath, pvr://)">$INFO[Container(1580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Season) + !String.IsEmpty(Container(1580).ListItem.Episode) + !String.Contains(Container(1580).ListItem.TvShowTitle,Container(1580).ListItem.Title)">[UPPERCASE]S$INFO[Container(1580).ListItem.Season]E$INFO[Container(1580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(1580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Title)">$INFO[Container(1580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Label)">$INFO[Container(1580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-1580">
+		<value condition="!String.IsEmpty(Container(1580).ListItem.TvShowTitle) + !String.IsEmpty(Container(1580).ListItem.Genre)">$INFO[Container(1580).ListItem.TvShowTitle,, • ]$INFO[Container(1580).ListItem.Year,, • ]$INFO[Container(1580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.TvShowTitle)">$INFO[Container(1580).ListItem.TvShowTitle,, • ]$INFO[Container(1580).ListItem.Premiered,, • ]$INFO[Container(1580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Year)">$INFO[Container(1580).ListItem.Year,, • ]$INFO[Container(1580).ListItem.Duration,,min. • ]$INFO[Container(1580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Artist) + !String.IsEmpty(Container(1580).ListItem.Album)">$INFO[Container(1580).ListItem.Artist,, • ]$INFO[Container(1580).ListItem.Album,, • ]$INFO[Container(1580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.Property(StartTime))">$INFO[Container(1580).ListItem.Property(ChannelName),, • ]$INFO[Container(1580).ListItem.Property(StartTime),, - ]$INFO[Container(1580).ListItem.Property(EndTime),, • ]$INFO[Container(1580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(1580).ListItem.StartTime)">$INFO[Container(1580).ListItem.ChannelName,, • ]$INFO[Container(1580).ListItem.StartTime,, - ]$INFO[Container(1580).ListItem.EndTime,, • ]$INFO[Container(1580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-1">
+		<value condition="Skin.String(widgetvalue-livetv,7)" />
+		<value condition="Skin.String(widgetvalue-livetv,6)" />
+		<value condition="Skin.String(widgetvalue-livetv,5)" />
+		<value condition="Skin.String(widgetvalue-livetv,4)" />
+		<value condition="Skin.String(widgetvalue-livetv,3)" />
+		<value condition="Skin.String(widgetvalue-livetv,2)" />
+		<value condition="Skin.String(widgetvalue-livetv,1)" />
+		<value>$LOCALIZE[19017]</value>
+	</variable>
+	<variable name="2510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>special://skin/playlists/video/InProgressMovies.xsp</value>
+	</variable>
+	<variable name="widgetinfolabel-2510">
+		<value condition="String.Contains(Container(2510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2510).ListItem.label] $INFO[Container(2510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Title) + String.Contains(Container(2510).ListItem.FolderPath, pvr://)">$INFO[Container(2510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Season) + !String.IsEmpty(Container(2510).ListItem.Episode) + !String.Contains(Container(2510).ListItem.TvShowTitle,Container(2510).ListItem.Title)">[UPPERCASE]S$INFO[Container(2510).ListItem.Season]E$INFO[Container(2510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Title)">$INFO[Container(2510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Label)">$INFO[Container(2510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2510">
+		<value condition="!String.IsEmpty(Container(2510).ListItem.TvShowTitle) + !String.IsEmpty(Container(2510).ListItem.Genre)">$INFO[Container(2510).ListItem.TvShowTitle,, • ]$INFO[Container(2510).ListItem.Year,, • ]$INFO[Container(2510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.TvShowTitle)">$INFO[Container(2510).ListItem.TvShowTitle,, • ]$INFO[Container(2510).ListItem.Premiered,, • ]$INFO[Container(2510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Year)">$INFO[Container(2510).ListItem.Year,, • ]$INFO[Container(2510).ListItem.Duration,,min. • ]$INFO[Container(2510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Artist) + !String.IsEmpty(Container(2510).ListItem.Album)">$INFO[Container(2510).ListItem.Artist,, • ]$INFO[Container(2510).ListItem.Album,, • ]$INFO[Container(2510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.Property(StartTime))">$INFO[Container(2510).ListItem.Property(ChannelName),, • ]$INFO[Container(2510).ListItem.Property(StartTime),, - ]$INFO[Container(2510).ListItem.Property(EndTime),, • ]$INFO[Container(2510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2510).ListItem.StartTime)">$INFO[Container(2510).ListItem.ChannelName,, • ]$INFO[Container(2510).ListItem.StartTime,, - ]$INFO[Container(2510).ListItem.EndTime,, • ]$INFO[Container(2510).ListItem.Genre]</value>
+	</variable>
+	<variable name="2520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>videodb://recentlyaddedmovies/</value>
+	</variable>
+	<variable name="widgetinfolabel-2520">
+		<value condition="String.Contains(Container(2520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2520).ListItem.label] $INFO[Container(2520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Title) + String.Contains(Container(2520).ListItem.FolderPath, pvr://)">$INFO[Container(2520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Season) + !String.IsEmpty(Container(2520).ListItem.Episode) + !String.Contains(Container(2520).ListItem.TvShowTitle,Container(2520).ListItem.Title)">[UPPERCASE]S$INFO[Container(2520).ListItem.Season]E$INFO[Container(2520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Title)">$INFO[Container(2520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Label)">$INFO[Container(2520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2520">
+		<value condition="!String.IsEmpty(Container(2520).ListItem.TvShowTitle) + !String.IsEmpty(Container(2520).ListItem.Genre)">$INFO[Container(2520).ListItem.TvShowTitle,, • ]$INFO[Container(2520).ListItem.Year,, • ]$INFO[Container(2520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.TvShowTitle)">$INFO[Container(2520).ListItem.TvShowTitle,, • ]$INFO[Container(2520).ListItem.Premiered,, • ]$INFO[Container(2520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Year)">$INFO[Container(2520).ListItem.Year,, • ]$INFO[Container(2520).ListItem.Duration,,min. • ]$INFO[Container(2520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Artist) + !String.IsEmpty(Container(2520).ListItem.Album)">$INFO[Container(2520).ListItem.Artist,, • ]$INFO[Container(2520).ListItem.Album,, • ]$INFO[Container(2520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.Property(StartTime))">$INFO[Container(2520).ListItem.Property(ChannelName),, • ]$INFO[Container(2520).ListItem.Property(StartTime),, - ]$INFO[Container(2520).ListItem.Property(EndTime),, • ]$INFO[Container(2520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2520).ListItem.StartTime)">$INFO[Container(2520).ListItem.ChannelName,, • ]$INFO[Container(2520).ListItem.StartTime,, - ]$INFO[Container(2520).ListItem.EndTime,, • ]$INFO[Container(2520).ListItem.Genre]</value>
+	</variable>
+	<variable name="2530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2530">
+		<value condition="String.Contains(Container(2530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2530).ListItem.label] $INFO[Container(2530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Title) + String.Contains(Container(2530).ListItem.FolderPath, pvr://)">$INFO[Container(2530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Season) + !String.IsEmpty(Container(2530).ListItem.Episode) + !String.Contains(Container(2530).ListItem.TvShowTitle,Container(2530).ListItem.Title)">[UPPERCASE]S$INFO[Container(2530).ListItem.Season]E$INFO[Container(2530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Title)">$INFO[Container(2530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Label)">$INFO[Container(2530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2530">
+		<value condition="!String.IsEmpty(Container(2530).ListItem.TvShowTitle) + !String.IsEmpty(Container(2530).ListItem.Genre)">$INFO[Container(2530).ListItem.TvShowTitle,, • ]$INFO[Container(2530).ListItem.Year,, • ]$INFO[Container(2530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.TvShowTitle)">$INFO[Container(2530).ListItem.TvShowTitle,, • ]$INFO[Container(2530).ListItem.Premiered,, • ]$INFO[Container(2530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Year)">$INFO[Container(2530).ListItem.Year,, • ]$INFO[Container(2530).ListItem.Duration,,min. • ]$INFO[Container(2530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Artist) + !String.IsEmpty(Container(2530).ListItem.Album)">$INFO[Container(2530).ListItem.Artist,, • ]$INFO[Container(2530).ListItem.Album,, • ]$INFO[Container(2530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.Property(StartTime))">$INFO[Container(2530).ListItem.Property(ChannelName),, • ]$INFO[Container(2530).ListItem.Property(StartTime),, - ]$INFO[Container(2530).ListItem.Property(EndTime),, • ]$INFO[Container(2530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2530).ListItem.StartTime)">$INFO[Container(2530).ListItem.ChannelName,, • ]$INFO[Container(2530).ListItem.StartTime,, - ]$INFO[Container(2530).ListItem.EndTime,, • ]$INFO[Container(2530).ListItem.Genre]</value>
+	</variable>
+	<variable name="2540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2540">
+		<value condition="String.Contains(Container(2540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2540).ListItem.label] $INFO[Container(2540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Title) + String.Contains(Container(2540).ListItem.FolderPath, pvr://)">$INFO[Container(2540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Season) + !String.IsEmpty(Container(2540).ListItem.Episode) + !String.Contains(Container(2540).ListItem.TvShowTitle,Container(2540).ListItem.Title)">[UPPERCASE]S$INFO[Container(2540).ListItem.Season]E$INFO[Container(2540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Title)">$INFO[Container(2540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Label)">$INFO[Container(2540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2540">
+		<value condition="!String.IsEmpty(Container(2540).ListItem.TvShowTitle) + !String.IsEmpty(Container(2540).ListItem.Genre)">$INFO[Container(2540).ListItem.TvShowTitle,, • ]$INFO[Container(2540).ListItem.Year,, • ]$INFO[Container(2540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.TvShowTitle)">$INFO[Container(2540).ListItem.TvShowTitle,, • ]$INFO[Container(2540).ListItem.Premiered,, • ]$INFO[Container(2540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Year)">$INFO[Container(2540).ListItem.Year,, • ]$INFO[Container(2540).ListItem.Duration,,min. • ]$INFO[Container(2540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Artist) + !String.IsEmpty(Container(2540).ListItem.Album)">$INFO[Container(2540).ListItem.Artist,, • ]$INFO[Container(2540).ListItem.Album,, • ]$INFO[Container(2540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.Property(StartTime))">$INFO[Container(2540).ListItem.Property(ChannelName),, • ]$INFO[Container(2540).ListItem.Property(StartTime),, - ]$INFO[Container(2540).ListItem.Property(EndTime),, • ]$INFO[Container(2540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2540).ListItem.StartTime)">$INFO[Container(2540).ListItem.ChannelName,, • ]$INFO[Container(2540).ListItem.StartTime,, - ]$INFO[Container(2540).ListItem.EndTime,, • ]$INFO[Container(2540).ListItem.Genre]</value>
+	</variable>
+	<variable name="2550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2550">
+		<value condition="String.Contains(Container(2550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2550).ListItem.label] $INFO[Container(2550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Title) + String.Contains(Container(2550).ListItem.FolderPath, pvr://)">$INFO[Container(2550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Season) + !String.IsEmpty(Container(2550).ListItem.Episode) + !String.Contains(Container(2550).ListItem.TvShowTitle,Container(2550).ListItem.Title)">[UPPERCASE]S$INFO[Container(2550).ListItem.Season]E$INFO[Container(2550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Title)">$INFO[Container(2550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Label)">$INFO[Container(2550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2550">
+		<value condition="!String.IsEmpty(Container(2550).ListItem.TvShowTitle) + !String.IsEmpty(Container(2550).ListItem.Genre)">$INFO[Container(2550).ListItem.TvShowTitle,, • ]$INFO[Container(2550).ListItem.Year,, • ]$INFO[Container(2550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.TvShowTitle)">$INFO[Container(2550).ListItem.TvShowTitle,, • ]$INFO[Container(2550).ListItem.Premiered,, • ]$INFO[Container(2550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Year)">$INFO[Container(2550).ListItem.Year,, • ]$INFO[Container(2550).ListItem.Duration,,min. • ]$INFO[Container(2550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Artist) + !String.IsEmpty(Container(2550).ListItem.Album)">$INFO[Container(2550).ListItem.Artist,, • ]$INFO[Container(2550).ListItem.Album,, • ]$INFO[Container(2550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.Property(StartTime))">$INFO[Container(2550).ListItem.Property(ChannelName),, • ]$INFO[Container(2550).ListItem.Property(StartTime),, - ]$INFO[Container(2550).ListItem.Property(EndTime),, • ]$INFO[Container(2550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2550).ListItem.StartTime)">$INFO[Container(2550).ListItem.ChannelName,, • ]$INFO[Container(2550).ListItem.StartTime,, - ]$INFO[Container(2550).ListItem.EndTime,, • ]$INFO[Container(2550).ListItem.Genre]</value>
+	</variable>
+	<variable name="2560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2560">
+		<value condition="String.Contains(Container(2560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2560).ListItem.label] $INFO[Container(2560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Title) + String.Contains(Container(2560).ListItem.FolderPath, pvr://)">$INFO[Container(2560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Season) + !String.IsEmpty(Container(2560).ListItem.Episode) + !String.Contains(Container(2560).ListItem.TvShowTitle,Container(2560).ListItem.Title)">[UPPERCASE]S$INFO[Container(2560).ListItem.Season]E$INFO[Container(2560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Title)">$INFO[Container(2560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Label)">$INFO[Container(2560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2560">
+		<value condition="!String.IsEmpty(Container(2560).ListItem.TvShowTitle) + !String.IsEmpty(Container(2560).ListItem.Genre)">$INFO[Container(2560).ListItem.TvShowTitle,, • ]$INFO[Container(2560).ListItem.Year,, • ]$INFO[Container(2560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.TvShowTitle)">$INFO[Container(2560).ListItem.TvShowTitle,, • ]$INFO[Container(2560).ListItem.Premiered,, • ]$INFO[Container(2560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Year)">$INFO[Container(2560).ListItem.Year,, • ]$INFO[Container(2560).ListItem.Duration,,min. • ]$INFO[Container(2560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Artist) + !String.IsEmpty(Container(2560).ListItem.Album)">$INFO[Container(2560).ListItem.Artist,, • ]$INFO[Container(2560).ListItem.Album,, • ]$INFO[Container(2560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.Property(StartTime))">$INFO[Container(2560).ListItem.Property(ChannelName),, • ]$INFO[Container(2560).ListItem.Property(StartTime),, - ]$INFO[Container(2560).ListItem.Property(EndTime),, • ]$INFO[Container(2560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2560).ListItem.StartTime)">$INFO[Container(2560).ListItem.ChannelName,, • ]$INFO[Container(2560).ListItem.StartTime,, - ]$INFO[Container(2560).ListItem.EndTime,, • ]$INFO[Container(2560).ListItem.Genre]</value>
+	</variable>
+	<variable name="2570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2570">
+		<value condition="String.Contains(Container(2570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2570).ListItem.label] $INFO[Container(2570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Title) + String.Contains(Container(2570).ListItem.FolderPath, pvr://)">$INFO[Container(2570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Season) + !String.IsEmpty(Container(2570).ListItem.Episode) + !String.Contains(Container(2570).ListItem.TvShowTitle,Container(2570).ListItem.Title)">[UPPERCASE]S$INFO[Container(2570).ListItem.Season]E$INFO[Container(2570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Title)">$INFO[Container(2570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Label)">$INFO[Container(2570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2570">
+		<value condition="!String.IsEmpty(Container(2570).ListItem.TvShowTitle) + !String.IsEmpty(Container(2570).ListItem.Genre)">$INFO[Container(2570).ListItem.TvShowTitle,, • ]$INFO[Container(2570).ListItem.Year,, • ]$INFO[Container(2570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.TvShowTitle)">$INFO[Container(2570).ListItem.TvShowTitle,, • ]$INFO[Container(2570).ListItem.Premiered,, • ]$INFO[Container(2570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Year)">$INFO[Container(2570).ListItem.Year,, • ]$INFO[Container(2570).ListItem.Duration,,min. • ]$INFO[Container(2570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Artist) + !String.IsEmpty(Container(2570).ListItem.Album)">$INFO[Container(2570).ListItem.Artist,, • ]$INFO[Container(2570).ListItem.Album,, • ]$INFO[Container(2570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.Property(StartTime))">$INFO[Container(2570).ListItem.Property(ChannelName),, • ]$INFO[Container(2570).ListItem.Property(StartTime),, - ]$INFO[Container(2570).ListItem.Property(EndTime),, • ]$INFO[Container(2570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2570).ListItem.StartTime)">$INFO[Container(2570).ListItem.ChannelName,, • ]$INFO[Container(2570).ListItem.StartTime,, - ]$INFO[Container(2570).ListItem.EndTime,, • ]$INFO[Container(2570).ListItem.Genre]</value>
+	</variable>
+	<variable name="2580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-2580">
+		<value condition="String.Contains(Container(2580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(2580).ListItem.label] $INFO[Container(2580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Title) + String.Contains(Container(2580).ListItem.FolderPath, pvr://)">$INFO[Container(2580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Season) + !String.IsEmpty(Container(2580).ListItem.Episode) + !String.Contains(Container(2580).ListItem.TvShowTitle,Container(2580).ListItem.Title)">[UPPERCASE]S$INFO[Container(2580).ListItem.Season]E$INFO[Container(2580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(2580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Title)">$INFO[Container(2580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Label)">$INFO[Container(2580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-2580">
+		<value condition="!String.IsEmpty(Container(2580).ListItem.TvShowTitle) + !String.IsEmpty(Container(2580).ListItem.Genre)">$INFO[Container(2580).ListItem.TvShowTitle,, • ]$INFO[Container(2580).ListItem.Year,, • ]$INFO[Container(2580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.TvShowTitle)">$INFO[Container(2580).ListItem.TvShowTitle,, • ]$INFO[Container(2580).ListItem.Premiered,, • ]$INFO[Container(2580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Year)">$INFO[Container(2580).ListItem.Year,, • ]$INFO[Container(2580).ListItem.Duration,,min. • ]$INFO[Container(2580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Artist) + !String.IsEmpty(Container(2580).ListItem.Album)">$INFO[Container(2580).ListItem.Artist,, • ]$INFO[Container(2580).ListItem.Album,, • ]$INFO[Container(2580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.Property(StartTime))">$INFO[Container(2580).ListItem.Property(ChannelName),, • ]$INFO[Container(2580).ListItem.Property(StartTime),, - ]$INFO[Container(2580).ListItem.Property(EndTime),, • ]$INFO[Container(2580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(2580).ListItem.StartTime)">$INFO[Container(2580).ListItem.ChannelName,, • ]$INFO[Container(2580).ListItem.StartTime,, - ]$INFO[Container(2580).ListItem.EndTime,, • ]$INFO[Container(2580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-2">
+		<value condition="Skin.String(widgetvalue-movies,7)" />
+		<value condition="Skin.String(widgetvalue-movies,6)" />
+		<value condition="Skin.String(widgetvalue-movies,5)" />
+		<value condition="Skin.String(widgetvalue-movies,4)" />
+		<value condition="Skin.String(widgetvalue-movies,3)" />
+		<value condition="Skin.String(widgetvalue-movies,2)" />
+		<value condition="Skin.String(widgetvalue-movies,1)">$LOCALIZE[20386]</value>
+		<value>In progress movies</value>
+	</variable>
+	<variable name="3510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>special://skin/playlists/video/InProgressEpisodes.xsp</value>
+	</variable>
+	<variable name="widgetinfolabel-3510">
+		<value condition="String.Contains(Container(3510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3510).ListItem.label] $INFO[Container(3510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Title) + String.Contains(Container(3510).ListItem.FolderPath, pvr://)">$INFO[Container(3510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Season) + !String.IsEmpty(Container(3510).ListItem.Episode) + !String.Contains(Container(3510).ListItem.TvShowTitle,Container(3510).ListItem.Title)">[UPPERCASE]S$INFO[Container(3510).ListItem.Season]E$INFO[Container(3510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Title)">$INFO[Container(3510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Label)">$INFO[Container(3510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3510">
+		<value condition="!String.IsEmpty(Container(3510).ListItem.TvShowTitle) + !String.IsEmpty(Container(3510).ListItem.Genre)">$INFO[Container(3510).ListItem.TvShowTitle,, • ]$INFO[Container(3510).ListItem.Year,, • ]$INFO[Container(3510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.TvShowTitle)">$INFO[Container(3510).ListItem.TvShowTitle,, • ]$INFO[Container(3510).ListItem.Premiered,, • ]$INFO[Container(3510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Year)">$INFO[Container(3510).ListItem.Year,, • ]$INFO[Container(3510).ListItem.Duration,,min. • ]$INFO[Container(3510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Artist) + !String.IsEmpty(Container(3510).ListItem.Album)">$INFO[Container(3510).ListItem.Artist,, • ]$INFO[Container(3510).ListItem.Album,, • ]$INFO[Container(3510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.Property(StartTime))">$INFO[Container(3510).ListItem.Property(ChannelName),, • ]$INFO[Container(3510).ListItem.Property(StartTime),, - ]$INFO[Container(3510).ListItem.Property(EndTime),, • ]$INFO[Container(3510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3510).ListItem.StartTime)">$INFO[Container(3510).ListItem.ChannelName,, • ]$INFO[Container(3510).ListItem.StartTime,, - ]$INFO[Container(3510).ListItem.EndTime,, • ]$INFO[Container(3510).ListItem.Genre]</value>
+	</variable>
+	<variable name="3520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>videodb://recentlyaddedepisodes/</value>
+	</variable>
+	<variable name="widgetinfolabel-3520">
+		<value condition="String.Contains(Container(3520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3520).ListItem.label] $INFO[Container(3520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Title) + String.Contains(Container(3520).ListItem.FolderPath, pvr://)">$INFO[Container(3520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Season) + !String.IsEmpty(Container(3520).ListItem.Episode) + !String.Contains(Container(3520).ListItem.TvShowTitle,Container(3520).ListItem.Title)">[UPPERCASE]S$INFO[Container(3520).ListItem.Season]E$INFO[Container(3520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Title)">$INFO[Container(3520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Label)">$INFO[Container(3520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3520">
+		<value condition="!String.IsEmpty(Container(3520).ListItem.TvShowTitle) + !String.IsEmpty(Container(3520).ListItem.Genre)">$INFO[Container(3520).ListItem.TvShowTitle,, • ]$INFO[Container(3520).ListItem.Year,, • ]$INFO[Container(3520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.TvShowTitle)">$INFO[Container(3520).ListItem.TvShowTitle,, • ]$INFO[Container(3520).ListItem.Premiered,, • ]$INFO[Container(3520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Year)">$INFO[Container(3520).ListItem.Year,, • ]$INFO[Container(3520).ListItem.Duration,,min. • ]$INFO[Container(3520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Artist) + !String.IsEmpty(Container(3520).ListItem.Album)">$INFO[Container(3520).ListItem.Artist,, • ]$INFO[Container(3520).ListItem.Album,, • ]$INFO[Container(3520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.Property(StartTime))">$INFO[Container(3520).ListItem.Property(ChannelName),, • ]$INFO[Container(3520).ListItem.Property(StartTime),, - ]$INFO[Container(3520).ListItem.Property(EndTime),, • ]$INFO[Container(3520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3520).ListItem.StartTime)">$INFO[Container(3520).ListItem.ChannelName,, • ]$INFO[Container(3520).ListItem.StartTime,, - ]$INFO[Container(3520).ListItem.EndTime,, • ]$INFO[Container(3520).ListItem.Genre]</value>
+	</variable>
+	<variable name="3530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3530">
+		<value condition="String.Contains(Container(3530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3530).ListItem.label] $INFO[Container(3530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Title) + String.Contains(Container(3530).ListItem.FolderPath, pvr://)">$INFO[Container(3530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Season) + !String.IsEmpty(Container(3530).ListItem.Episode) + !String.Contains(Container(3530).ListItem.TvShowTitle,Container(3530).ListItem.Title)">[UPPERCASE]S$INFO[Container(3530).ListItem.Season]E$INFO[Container(3530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Title)">$INFO[Container(3530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Label)">$INFO[Container(3530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3530">
+		<value condition="!String.IsEmpty(Container(3530).ListItem.TvShowTitle) + !String.IsEmpty(Container(3530).ListItem.Genre)">$INFO[Container(3530).ListItem.TvShowTitle,, • ]$INFO[Container(3530).ListItem.Year,, • ]$INFO[Container(3530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.TvShowTitle)">$INFO[Container(3530).ListItem.TvShowTitle,, • ]$INFO[Container(3530).ListItem.Premiered,, • ]$INFO[Container(3530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Year)">$INFO[Container(3530).ListItem.Year,, • ]$INFO[Container(3530).ListItem.Duration,,min. • ]$INFO[Container(3530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Artist) + !String.IsEmpty(Container(3530).ListItem.Album)">$INFO[Container(3530).ListItem.Artist,, • ]$INFO[Container(3530).ListItem.Album,, • ]$INFO[Container(3530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.Property(StartTime))">$INFO[Container(3530).ListItem.Property(ChannelName),, • ]$INFO[Container(3530).ListItem.Property(StartTime),, - ]$INFO[Container(3530).ListItem.Property(EndTime),, • ]$INFO[Container(3530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3530).ListItem.StartTime)">$INFO[Container(3530).ListItem.ChannelName,, • ]$INFO[Container(3530).ListItem.StartTime,, - ]$INFO[Container(3530).ListItem.EndTime,, • ]$INFO[Container(3530).ListItem.Genre]</value>
+	</variable>
+	<variable name="3540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3540">
+		<value condition="String.Contains(Container(3540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3540).ListItem.label] $INFO[Container(3540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Title) + String.Contains(Container(3540).ListItem.FolderPath, pvr://)">$INFO[Container(3540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Season) + !String.IsEmpty(Container(3540).ListItem.Episode) + !String.Contains(Container(3540).ListItem.TvShowTitle,Container(3540).ListItem.Title)">[UPPERCASE]S$INFO[Container(3540).ListItem.Season]E$INFO[Container(3540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Title)">$INFO[Container(3540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Label)">$INFO[Container(3540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3540">
+		<value condition="!String.IsEmpty(Container(3540).ListItem.TvShowTitle) + !String.IsEmpty(Container(3540).ListItem.Genre)">$INFO[Container(3540).ListItem.TvShowTitle,, • ]$INFO[Container(3540).ListItem.Year,, • ]$INFO[Container(3540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.TvShowTitle)">$INFO[Container(3540).ListItem.TvShowTitle,, • ]$INFO[Container(3540).ListItem.Premiered,, • ]$INFO[Container(3540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Year)">$INFO[Container(3540).ListItem.Year,, • ]$INFO[Container(3540).ListItem.Duration,,min. • ]$INFO[Container(3540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Artist) + !String.IsEmpty(Container(3540).ListItem.Album)">$INFO[Container(3540).ListItem.Artist,, • ]$INFO[Container(3540).ListItem.Album,, • ]$INFO[Container(3540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.Property(StartTime))">$INFO[Container(3540).ListItem.Property(ChannelName),, • ]$INFO[Container(3540).ListItem.Property(StartTime),, - ]$INFO[Container(3540).ListItem.Property(EndTime),, • ]$INFO[Container(3540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3540).ListItem.StartTime)">$INFO[Container(3540).ListItem.ChannelName,, • ]$INFO[Container(3540).ListItem.StartTime,, - ]$INFO[Container(3540).ListItem.EndTime,, • ]$INFO[Container(3540).ListItem.Genre]</value>
+	</variable>
+	<variable name="3550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3550">
+		<value condition="String.Contains(Container(3550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3550).ListItem.label] $INFO[Container(3550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Title) + String.Contains(Container(3550).ListItem.FolderPath, pvr://)">$INFO[Container(3550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Season) + !String.IsEmpty(Container(3550).ListItem.Episode) + !String.Contains(Container(3550).ListItem.TvShowTitle,Container(3550).ListItem.Title)">[UPPERCASE]S$INFO[Container(3550).ListItem.Season]E$INFO[Container(3550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Title)">$INFO[Container(3550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Label)">$INFO[Container(3550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3550">
+		<value condition="!String.IsEmpty(Container(3550).ListItem.TvShowTitle) + !String.IsEmpty(Container(3550).ListItem.Genre)">$INFO[Container(3550).ListItem.TvShowTitle,, • ]$INFO[Container(3550).ListItem.Year,, • ]$INFO[Container(3550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.TvShowTitle)">$INFO[Container(3550).ListItem.TvShowTitle,, • ]$INFO[Container(3550).ListItem.Premiered,, • ]$INFO[Container(3550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Year)">$INFO[Container(3550).ListItem.Year,, • ]$INFO[Container(3550).ListItem.Duration,,min. • ]$INFO[Container(3550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Artist) + !String.IsEmpty(Container(3550).ListItem.Album)">$INFO[Container(3550).ListItem.Artist,, • ]$INFO[Container(3550).ListItem.Album,, • ]$INFO[Container(3550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.Property(StartTime))">$INFO[Container(3550).ListItem.Property(ChannelName),, • ]$INFO[Container(3550).ListItem.Property(StartTime),, - ]$INFO[Container(3550).ListItem.Property(EndTime),, • ]$INFO[Container(3550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3550).ListItem.StartTime)">$INFO[Container(3550).ListItem.ChannelName,, • ]$INFO[Container(3550).ListItem.StartTime,, - ]$INFO[Container(3550).ListItem.EndTime,, • ]$INFO[Container(3550).ListItem.Genre]</value>
+	</variable>
+	<variable name="3560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3560">
+		<value condition="String.Contains(Container(3560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3560).ListItem.label] $INFO[Container(3560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Title) + String.Contains(Container(3560).ListItem.FolderPath, pvr://)">$INFO[Container(3560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Season) + !String.IsEmpty(Container(3560).ListItem.Episode) + !String.Contains(Container(3560).ListItem.TvShowTitle,Container(3560).ListItem.Title)">[UPPERCASE]S$INFO[Container(3560).ListItem.Season]E$INFO[Container(3560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Title)">$INFO[Container(3560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Label)">$INFO[Container(3560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3560">
+		<value condition="!String.IsEmpty(Container(3560).ListItem.TvShowTitle) + !String.IsEmpty(Container(3560).ListItem.Genre)">$INFO[Container(3560).ListItem.TvShowTitle,, • ]$INFO[Container(3560).ListItem.Year,, • ]$INFO[Container(3560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.TvShowTitle)">$INFO[Container(3560).ListItem.TvShowTitle,, • ]$INFO[Container(3560).ListItem.Premiered,, • ]$INFO[Container(3560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Year)">$INFO[Container(3560).ListItem.Year,, • ]$INFO[Container(3560).ListItem.Duration,,min. • ]$INFO[Container(3560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Artist) + !String.IsEmpty(Container(3560).ListItem.Album)">$INFO[Container(3560).ListItem.Artist,, • ]$INFO[Container(3560).ListItem.Album,, • ]$INFO[Container(3560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.Property(StartTime))">$INFO[Container(3560).ListItem.Property(ChannelName),, • ]$INFO[Container(3560).ListItem.Property(StartTime),, - ]$INFO[Container(3560).ListItem.Property(EndTime),, • ]$INFO[Container(3560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3560).ListItem.StartTime)">$INFO[Container(3560).ListItem.ChannelName,, • ]$INFO[Container(3560).ListItem.StartTime,, - ]$INFO[Container(3560).ListItem.EndTime,, • ]$INFO[Container(3560).ListItem.Genre]</value>
+	</variable>
+	<variable name="3570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3570">
+		<value condition="String.Contains(Container(3570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3570).ListItem.label] $INFO[Container(3570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Title) + String.Contains(Container(3570).ListItem.FolderPath, pvr://)">$INFO[Container(3570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Season) + !String.IsEmpty(Container(3570).ListItem.Episode) + !String.Contains(Container(3570).ListItem.TvShowTitle,Container(3570).ListItem.Title)">[UPPERCASE]S$INFO[Container(3570).ListItem.Season]E$INFO[Container(3570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Title)">$INFO[Container(3570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Label)">$INFO[Container(3570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3570">
+		<value condition="!String.IsEmpty(Container(3570).ListItem.TvShowTitle) + !String.IsEmpty(Container(3570).ListItem.Genre)">$INFO[Container(3570).ListItem.TvShowTitle,, • ]$INFO[Container(3570).ListItem.Year,, • ]$INFO[Container(3570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.TvShowTitle)">$INFO[Container(3570).ListItem.TvShowTitle,, • ]$INFO[Container(3570).ListItem.Premiered,, • ]$INFO[Container(3570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Year)">$INFO[Container(3570).ListItem.Year,, • ]$INFO[Container(3570).ListItem.Duration,,min. • ]$INFO[Container(3570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Artist) + !String.IsEmpty(Container(3570).ListItem.Album)">$INFO[Container(3570).ListItem.Artist,, • ]$INFO[Container(3570).ListItem.Album,, • ]$INFO[Container(3570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.Property(StartTime))">$INFO[Container(3570).ListItem.Property(ChannelName),, • ]$INFO[Container(3570).ListItem.Property(StartTime),, - ]$INFO[Container(3570).ListItem.Property(EndTime),, • ]$INFO[Container(3570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3570).ListItem.StartTime)">$INFO[Container(3570).ListItem.ChannelName,, • ]$INFO[Container(3570).ListItem.StartTime,, - ]$INFO[Container(3570).ListItem.EndTime,, • ]$INFO[Container(3570).ListItem.Genre]</value>
+	</variable>
+	<variable name="3580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-3580">
+		<value condition="String.Contains(Container(3580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(3580).ListItem.label] $INFO[Container(3580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Title) + String.Contains(Container(3580).ListItem.FolderPath, pvr://)">$INFO[Container(3580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Season) + !String.IsEmpty(Container(3580).ListItem.Episode) + !String.Contains(Container(3580).ListItem.TvShowTitle,Container(3580).ListItem.Title)">[UPPERCASE]S$INFO[Container(3580).ListItem.Season]E$INFO[Container(3580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(3580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Title)">$INFO[Container(3580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Label)">$INFO[Container(3580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-3580">
+		<value condition="!String.IsEmpty(Container(3580).ListItem.TvShowTitle) + !String.IsEmpty(Container(3580).ListItem.Genre)">$INFO[Container(3580).ListItem.TvShowTitle,, • ]$INFO[Container(3580).ListItem.Year,, • ]$INFO[Container(3580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.TvShowTitle)">$INFO[Container(3580).ListItem.TvShowTitle,, • ]$INFO[Container(3580).ListItem.Premiered,, • ]$INFO[Container(3580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Year)">$INFO[Container(3580).ListItem.Year,, • ]$INFO[Container(3580).ListItem.Duration,,min. • ]$INFO[Container(3580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Artist) + !String.IsEmpty(Container(3580).ListItem.Album)">$INFO[Container(3580).ListItem.Artist,, • ]$INFO[Container(3580).ListItem.Album,, • ]$INFO[Container(3580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.Property(StartTime))">$INFO[Container(3580).ListItem.Property(ChannelName),, • ]$INFO[Container(3580).ListItem.Property(StartTime),, - ]$INFO[Container(3580).ListItem.Property(EndTime),, • ]$INFO[Container(3580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(3580).ListItem.StartTime)">$INFO[Container(3580).ListItem.ChannelName,, • ]$INFO[Container(3580).ListItem.StartTime,, - ]$INFO[Container(3580).ListItem.EndTime,, • ]$INFO[Container(3580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-3">
+		<value condition="Skin.String(widgetvalue-tvshows,7)" />
+		<value condition="Skin.String(widgetvalue-tvshows,6)" />
+		<value condition="Skin.String(widgetvalue-tvshows,5)" />
+		<value condition="Skin.String(widgetvalue-tvshows,4)" />
+		<value condition="Skin.String(widgetvalue-tvshows,3)" />
+		<value condition="Skin.String(widgetvalue-tvshows,2)" />
+		<value condition="Skin.String(widgetvalue-tvshows,1)">$LOCALIZE[20387]</value>
+		<value>In progress episodes</value>
+	</variable>
+	<variable name="5510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value>videodb://recentlyaddedmusicvideos/</value>
+	</variable>
+	<variable name="widgetinfolabel-5510">
+		<value condition="String.Contains(Container(5510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5510).ListItem.label] $INFO[Container(5510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Title) + String.Contains(Container(5510).ListItem.FolderPath, pvr://)">$INFO[Container(5510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Season) + !String.IsEmpty(Container(5510).ListItem.Episode) + !String.Contains(Container(5510).ListItem.TvShowTitle,Container(5510).ListItem.Title)">[UPPERCASE]S$INFO[Container(5510).ListItem.Season]E$INFO[Container(5510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Title)">$INFO[Container(5510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Label)">$INFO[Container(5510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5510">
+		<value condition="!String.IsEmpty(Container(5510).ListItem.TvShowTitle) + !String.IsEmpty(Container(5510).ListItem.Genre)">$INFO[Container(5510).ListItem.TvShowTitle,, • ]$INFO[Container(5510).ListItem.Year,, • ]$INFO[Container(5510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.TvShowTitle)">$INFO[Container(5510).ListItem.TvShowTitle,, • ]$INFO[Container(5510).ListItem.Premiered,, • ]$INFO[Container(5510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Year)">$INFO[Container(5510).ListItem.Year,, • ]$INFO[Container(5510).ListItem.Duration,,min. • ]$INFO[Container(5510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Artist) + !String.IsEmpty(Container(5510).ListItem.Album)">$INFO[Container(5510).ListItem.Artist,, • ]$INFO[Container(5510).ListItem.Album,, • ]$INFO[Container(5510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.Property(StartTime))">$INFO[Container(5510).ListItem.Property(ChannelName),, • ]$INFO[Container(5510).ListItem.Property(StartTime),, - ]$INFO[Container(5510).ListItem.Property(EndTime),, • ]$INFO[Container(5510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5510).ListItem.StartTime)">$INFO[Container(5510).ListItem.ChannelName,, • ]$INFO[Container(5510).ListItem.StartTime,, - ]$INFO[Container(5510).ListItem.EndTime,, • ]$INFO[Container(5510).ListItem.Genre]</value>
+	</variable>
+	<variable name="5520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5520">
+		<value condition="String.Contains(Container(5520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5520).ListItem.label] $INFO[Container(5520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Title) + String.Contains(Container(5520).ListItem.FolderPath, pvr://)">$INFO[Container(5520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Season) + !String.IsEmpty(Container(5520).ListItem.Episode) + !String.Contains(Container(5520).ListItem.TvShowTitle,Container(5520).ListItem.Title)">[UPPERCASE]S$INFO[Container(5520).ListItem.Season]E$INFO[Container(5520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Title)">$INFO[Container(5520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Label)">$INFO[Container(5520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5520">
+		<value condition="!String.IsEmpty(Container(5520).ListItem.TvShowTitle) + !String.IsEmpty(Container(5520).ListItem.Genre)">$INFO[Container(5520).ListItem.TvShowTitle,, • ]$INFO[Container(5520).ListItem.Year,, • ]$INFO[Container(5520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.TvShowTitle)">$INFO[Container(5520).ListItem.TvShowTitle,, • ]$INFO[Container(5520).ListItem.Premiered,, • ]$INFO[Container(5520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Year)">$INFO[Container(5520).ListItem.Year,, • ]$INFO[Container(5520).ListItem.Duration,,min. • ]$INFO[Container(5520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Artist) + !String.IsEmpty(Container(5520).ListItem.Album)">$INFO[Container(5520).ListItem.Artist,, • ]$INFO[Container(5520).ListItem.Album,, • ]$INFO[Container(5520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.Property(StartTime))">$INFO[Container(5520).ListItem.Property(ChannelName),, • ]$INFO[Container(5520).ListItem.Property(StartTime),, - ]$INFO[Container(5520).ListItem.Property(EndTime),, • ]$INFO[Container(5520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5520).ListItem.StartTime)">$INFO[Container(5520).ListItem.ChannelName,, • ]$INFO[Container(5520).ListItem.StartTime,, - ]$INFO[Container(5520).ListItem.EndTime,, • ]$INFO[Container(5520).ListItem.Genre]</value>
+	</variable>
+	<variable name="5530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5530">
+		<value condition="String.Contains(Container(5530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5530).ListItem.label] $INFO[Container(5530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Title) + String.Contains(Container(5530).ListItem.FolderPath, pvr://)">$INFO[Container(5530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Season) + !String.IsEmpty(Container(5530).ListItem.Episode) + !String.Contains(Container(5530).ListItem.TvShowTitle,Container(5530).ListItem.Title)">[UPPERCASE]S$INFO[Container(5530).ListItem.Season]E$INFO[Container(5530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Title)">$INFO[Container(5530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Label)">$INFO[Container(5530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5530">
+		<value condition="!String.IsEmpty(Container(5530).ListItem.TvShowTitle) + !String.IsEmpty(Container(5530).ListItem.Genre)">$INFO[Container(5530).ListItem.TvShowTitle,, • ]$INFO[Container(5530).ListItem.Year,, • ]$INFO[Container(5530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.TvShowTitle)">$INFO[Container(5530).ListItem.TvShowTitle,, • ]$INFO[Container(5530).ListItem.Premiered,, • ]$INFO[Container(5530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Year)">$INFO[Container(5530).ListItem.Year,, • ]$INFO[Container(5530).ListItem.Duration,,min. • ]$INFO[Container(5530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Artist) + !String.IsEmpty(Container(5530).ListItem.Album)">$INFO[Container(5530).ListItem.Artist,, • ]$INFO[Container(5530).ListItem.Album,, • ]$INFO[Container(5530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.Property(StartTime))">$INFO[Container(5530).ListItem.Property(ChannelName),, • ]$INFO[Container(5530).ListItem.Property(StartTime),, - ]$INFO[Container(5530).ListItem.Property(EndTime),, • ]$INFO[Container(5530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5530).ListItem.StartTime)">$INFO[Container(5530).ListItem.ChannelName,, • ]$INFO[Container(5530).ListItem.StartTime,, - ]$INFO[Container(5530).ListItem.EndTime,, • ]$INFO[Container(5530).ListItem.Genre]</value>
+	</variable>
+	<variable name="5540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5540">
+		<value condition="String.Contains(Container(5540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5540).ListItem.label] $INFO[Container(5540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Title) + String.Contains(Container(5540).ListItem.FolderPath, pvr://)">$INFO[Container(5540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Season) + !String.IsEmpty(Container(5540).ListItem.Episode) + !String.Contains(Container(5540).ListItem.TvShowTitle,Container(5540).ListItem.Title)">[UPPERCASE]S$INFO[Container(5540).ListItem.Season]E$INFO[Container(5540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Title)">$INFO[Container(5540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Label)">$INFO[Container(5540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5540">
+		<value condition="!String.IsEmpty(Container(5540).ListItem.TvShowTitle) + !String.IsEmpty(Container(5540).ListItem.Genre)">$INFO[Container(5540).ListItem.TvShowTitle,, • ]$INFO[Container(5540).ListItem.Year,, • ]$INFO[Container(5540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.TvShowTitle)">$INFO[Container(5540).ListItem.TvShowTitle,, • ]$INFO[Container(5540).ListItem.Premiered,, • ]$INFO[Container(5540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Year)">$INFO[Container(5540).ListItem.Year,, • ]$INFO[Container(5540).ListItem.Duration,,min. • ]$INFO[Container(5540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Artist) + !String.IsEmpty(Container(5540).ListItem.Album)">$INFO[Container(5540).ListItem.Artist,, • ]$INFO[Container(5540).ListItem.Album,, • ]$INFO[Container(5540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.Property(StartTime))">$INFO[Container(5540).ListItem.Property(ChannelName),, • ]$INFO[Container(5540).ListItem.Property(StartTime),, - ]$INFO[Container(5540).ListItem.Property(EndTime),, • ]$INFO[Container(5540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5540).ListItem.StartTime)">$INFO[Container(5540).ListItem.ChannelName,, • ]$INFO[Container(5540).ListItem.StartTime,, - ]$INFO[Container(5540).ListItem.EndTime,, • ]$INFO[Container(5540).ListItem.Genre]</value>
+	</variable>
+	<variable name="5550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5550">
+		<value condition="String.Contains(Container(5550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5550).ListItem.label] $INFO[Container(5550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Title) + String.Contains(Container(5550).ListItem.FolderPath, pvr://)">$INFO[Container(5550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Season) + !String.IsEmpty(Container(5550).ListItem.Episode) + !String.Contains(Container(5550).ListItem.TvShowTitle,Container(5550).ListItem.Title)">[UPPERCASE]S$INFO[Container(5550).ListItem.Season]E$INFO[Container(5550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Title)">$INFO[Container(5550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Label)">$INFO[Container(5550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5550">
+		<value condition="!String.IsEmpty(Container(5550).ListItem.TvShowTitle) + !String.IsEmpty(Container(5550).ListItem.Genre)">$INFO[Container(5550).ListItem.TvShowTitle,, • ]$INFO[Container(5550).ListItem.Year,, • ]$INFO[Container(5550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.TvShowTitle)">$INFO[Container(5550).ListItem.TvShowTitle,, • ]$INFO[Container(5550).ListItem.Premiered,, • ]$INFO[Container(5550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Year)">$INFO[Container(5550).ListItem.Year,, • ]$INFO[Container(5550).ListItem.Duration,,min. • ]$INFO[Container(5550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Artist) + !String.IsEmpty(Container(5550).ListItem.Album)">$INFO[Container(5550).ListItem.Artist,, • ]$INFO[Container(5550).ListItem.Album,, • ]$INFO[Container(5550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.Property(StartTime))">$INFO[Container(5550).ListItem.Property(ChannelName),, • ]$INFO[Container(5550).ListItem.Property(StartTime),, - ]$INFO[Container(5550).ListItem.Property(EndTime),, • ]$INFO[Container(5550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5550).ListItem.StartTime)">$INFO[Container(5550).ListItem.ChannelName,, • ]$INFO[Container(5550).ListItem.StartTime,, - ]$INFO[Container(5550).ListItem.EndTime,, • ]$INFO[Container(5550).ListItem.Genre]</value>
+	</variable>
+	<variable name="5560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5560">
+		<value condition="String.Contains(Container(5560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5560).ListItem.label] $INFO[Container(5560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Title) + String.Contains(Container(5560).ListItem.FolderPath, pvr://)">$INFO[Container(5560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Season) + !String.IsEmpty(Container(5560).ListItem.Episode) + !String.Contains(Container(5560).ListItem.TvShowTitle,Container(5560).ListItem.Title)">[UPPERCASE]S$INFO[Container(5560).ListItem.Season]E$INFO[Container(5560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Title)">$INFO[Container(5560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Label)">$INFO[Container(5560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5560">
+		<value condition="!String.IsEmpty(Container(5560).ListItem.TvShowTitle) + !String.IsEmpty(Container(5560).ListItem.Genre)">$INFO[Container(5560).ListItem.TvShowTitle,, • ]$INFO[Container(5560).ListItem.Year,, • ]$INFO[Container(5560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.TvShowTitle)">$INFO[Container(5560).ListItem.TvShowTitle,, • ]$INFO[Container(5560).ListItem.Premiered,, • ]$INFO[Container(5560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Year)">$INFO[Container(5560).ListItem.Year,, • ]$INFO[Container(5560).ListItem.Duration,,min. • ]$INFO[Container(5560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Artist) + !String.IsEmpty(Container(5560).ListItem.Album)">$INFO[Container(5560).ListItem.Artist,, • ]$INFO[Container(5560).ListItem.Album,, • ]$INFO[Container(5560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.Property(StartTime))">$INFO[Container(5560).ListItem.Property(ChannelName),, • ]$INFO[Container(5560).ListItem.Property(StartTime),, - ]$INFO[Container(5560).ListItem.Property(EndTime),, • ]$INFO[Container(5560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5560).ListItem.StartTime)">$INFO[Container(5560).ListItem.ChannelName,, • ]$INFO[Container(5560).ListItem.StartTime,, - ]$INFO[Container(5560).ListItem.EndTime,, • ]$INFO[Container(5560).ListItem.Genre]</value>
+	</variable>
+	<variable name="5570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5570">
+		<value condition="String.Contains(Container(5570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5570).ListItem.label] $INFO[Container(5570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Title) + String.Contains(Container(5570).ListItem.FolderPath, pvr://)">$INFO[Container(5570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Season) + !String.IsEmpty(Container(5570).ListItem.Episode) + !String.Contains(Container(5570).ListItem.TvShowTitle,Container(5570).ListItem.Title)">[UPPERCASE]S$INFO[Container(5570).ListItem.Season]E$INFO[Container(5570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Title)">$INFO[Container(5570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Label)">$INFO[Container(5570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5570">
+		<value condition="!String.IsEmpty(Container(5570).ListItem.TvShowTitle) + !String.IsEmpty(Container(5570).ListItem.Genre)">$INFO[Container(5570).ListItem.TvShowTitle,, • ]$INFO[Container(5570).ListItem.Year,, • ]$INFO[Container(5570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.TvShowTitle)">$INFO[Container(5570).ListItem.TvShowTitle,, • ]$INFO[Container(5570).ListItem.Premiered,, • ]$INFO[Container(5570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Year)">$INFO[Container(5570).ListItem.Year,, • ]$INFO[Container(5570).ListItem.Duration,,min. • ]$INFO[Container(5570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Artist) + !String.IsEmpty(Container(5570).ListItem.Album)">$INFO[Container(5570).ListItem.Artist,, • ]$INFO[Container(5570).ListItem.Album,, • ]$INFO[Container(5570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.Property(StartTime))">$INFO[Container(5570).ListItem.Property(ChannelName),, • ]$INFO[Container(5570).ListItem.Property(StartTime),, - ]$INFO[Container(5570).ListItem.Property(EndTime),, • ]$INFO[Container(5570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5570).ListItem.StartTime)">$INFO[Container(5570).ListItem.ChannelName,, • ]$INFO[Container(5570).ListItem.StartTime,, - ]$INFO[Container(5570).ListItem.EndTime,, • ]$INFO[Container(5570).ListItem.Genre]</value>
+	</variable>
+	<variable name="5580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-5580">
+		<value condition="String.Contains(Container(5580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(5580).ListItem.label] $INFO[Container(5580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Title) + String.Contains(Container(5580).ListItem.FolderPath, pvr://)">$INFO[Container(5580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Season) + !String.IsEmpty(Container(5580).ListItem.Episode) + !String.Contains(Container(5580).ListItem.TvShowTitle,Container(5580).ListItem.Title)">[UPPERCASE]S$INFO[Container(5580).ListItem.Season]E$INFO[Container(5580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(5580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Title)">$INFO[Container(5580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Label)">$INFO[Container(5580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-5580">
+		<value condition="!String.IsEmpty(Container(5580).ListItem.TvShowTitle) + !String.IsEmpty(Container(5580).ListItem.Genre)">$INFO[Container(5580).ListItem.TvShowTitle,, • ]$INFO[Container(5580).ListItem.Year,, • ]$INFO[Container(5580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.TvShowTitle)">$INFO[Container(5580).ListItem.TvShowTitle,, • ]$INFO[Container(5580).ListItem.Premiered,, • ]$INFO[Container(5580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Year)">$INFO[Container(5580).ListItem.Year,, • ]$INFO[Container(5580).ListItem.Duration,,min. • ]$INFO[Container(5580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Artist) + !String.IsEmpty(Container(5580).ListItem.Album)">$INFO[Container(5580).ListItem.Artist,, • ]$INFO[Container(5580).ListItem.Album,, • ]$INFO[Container(5580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.Property(StartTime))">$INFO[Container(5580).ListItem.Property(ChannelName),, • ]$INFO[Container(5580).ListItem.Property(StartTime),, - ]$INFO[Container(5580).ListItem.Property(EndTime),, • ]$INFO[Container(5580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(5580).ListItem.StartTime)">$INFO[Container(5580).ListItem.ChannelName,, • ]$INFO[Container(5580).ListItem.StartTime,, - ]$INFO[Container(5580).ListItem.EndTime,, • ]$INFO[Container(5580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-5">
+		<value condition="Skin.String(widgetvalue-musicvideos,7)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,6)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,5)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,4)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,3)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,2)" />
+		<value condition="Skin.String(widgetvalue-musicvideos,1)" />
+		<value>$LOCALIZE[20390]</value>
+	</variable>
+	<variable name="6510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6510">
+		<value condition="String.Contains(Container(6510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6510).ListItem.label] $INFO[Container(6510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Title) + String.Contains(Container(6510).ListItem.FolderPath, pvr://)">$INFO[Container(6510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Season) + !String.IsEmpty(Container(6510).ListItem.Episode) + !String.Contains(Container(6510).ListItem.TvShowTitle,Container(6510).ListItem.Title)">[UPPERCASE]S$INFO[Container(6510).ListItem.Season]E$INFO[Container(6510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Title)">$INFO[Container(6510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Label)">$INFO[Container(6510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6510">
+		<value condition="!String.IsEmpty(Container(6510).ListItem.TvShowTitle) + !String.IsEmpty(Container(6510).ListItem.Genre)">$INFO[Container(6510).ListItem.TvShowTitle,, • ]$INFO[Container(6510).ListItem.Year,, • ]$INFO[Container(6510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.TvShowTitle)">$INFO[Container(6510).ListItem.TvShowTitle,, • ]$INFO[Container(6510).ListItem.Premiered,, • ]$INFO[Container(6510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Year)">$INFO[Container(6510).ListItem.Year,, • ]$INFO[Container(6510).ListItem.Duration,,min. • ]$INFO[Container(6510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Artist) + !String.IsEmpty(Container(6510).ListItem.Album)">$INFO[Container(6510).ListItem.Artist,, • ]$INFO[Container(6510).ListItem.Album,, • ]$INFO[Container(6510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.Property(StartTime))">$INFO[Container(6510).ListItem.Property(ChannelName),, • ]$INFO[Container(6510).ListItem.Property(StartTime),, - ]$INFO[Container(6510).ListItem.Property(EndTime),, • ]$INFO[Container(6510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6510).ListItem.StartTime)">$INFO[Container(6510).ListItem.ChannelName,, • ]$INFO[Container(6510).ListItem.StartTime,, - ]$INFO[Container(6510).ListItem.EndTime,, • ]$INFO[Container(6510).ListItem.Genre]</value>
+	</variable>
+	<variable name="6520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6520">
+		<value condition="String.Contains(Container(6520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6520).ListItem.label] $INFO[Container(6520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Title) + String.Contains(Container(6520).ListItem.FolderPath, pvr://)">$INFO[Container(6520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Season) + !String.IsEmpty(Container(6520).ListItem.Episode) + !String.Contains(Container(6520).ListItem.TvShowTitle,Container(6520).ListItem.Title)">[UPPERCASE]S$INFO[Container(6520).ListItem.Season]E$INFO[Container(6520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Title)">$INFO[Container(6520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Label)">$INFO[Container(6520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6520">
+		<value condition="!String.IsEmpty(Container(6520).ListItem.TvShowTitle) + !String.IsEmpty(Container(6520).ListItem.Genre)">$INFO[Container(6520).ListItem.TvShowTitle,, • ]$INFO[Container(6520).ListItem.Year,, • ]$INFO[Container(6520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.TvShowTitle)">$INFO[Container(6520).ListItem.TvShowTitle,, • ]$INFO[Container(6520).ListItem.Premiered,, • ]$INFO[Container(6520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Year)">$INFO[Container(6520).ListItem.Year,, • ]$INFO[Container(6520).ListItem.Duration,,min. • ]$INFO[Container(6520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Artist) + !String.IsEmpty(Container(6520).ListItem.Album)">$INFO[Container(6520).ListItem.Artist,, • ]$INFO[Container(6520).ListItem.Album,, • ]$INFO[Container(6520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.Property(StartTime))">$INFO[Container(6520).ListItem.Property(ChannelName),, • ]$INFO[Container(6520).ListItem.Property(StartTime),, - ]$INFO[Container(6520).ListItem.Property(EndTime),, • ]$INFO[Container(6520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6520).ListItem.StartTime)">$INFO[Container(6520).ListItem.ChannelName,, • ]$INFO[Container(6520).ListItem.StartTime,, - ]$INFO[Container(6520).ListItem.EndTime,, • ]$INFO[Container(6520).ListItem.Genre]</value>
+	</variable>
+	<variable name="6530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6530">
+		<value condition="String.Contains(Container(6530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6530).ListItem.label] $INFO[Container(6530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Title) + String.Contains(Container(6530).ListItem.FolderPath, pvr://)">$INFO[Container(6530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Season) + !String.IsEmpty(Container(6530).ListItem.Episode) + !String.Contains(Container(6530).ListItem.TvShowTitle,Container(6530).ListItem.Title)">[UPPERCASE]S$INFO[Container(6530).ListItem.Season]E$INFO[Container(6530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Title)">$INFO[Container(6530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Label)">$INFO[Container(6530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6530">
+		<value condition="!String.IsEmpty(Container(6530).ListItem.TvShowTitle) + !String.IsEmpty(Container(6530).ListItem.Genre)">$INFO[Container(6530).ListItem.TvShowTitle,, • ]$INFO[Container(6530).ListItem.Year,, • ]$INFO[Container(6530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.TvShowTitle)">$INFO[Container(6530).ListItem.TvShowTitle,, • ]$INFO[Container(6530).ListItem.Premiered,, • ]$INFO[Container(6530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Year)">$INFO[Container(6530).ListItem.Year,, • ]$INFO[Container(6530).ListItem.Duration,,min. • ]$INFO[Container(6530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Artist) + !String.IsEmpty(Container(6530).ListItem.Album)">$INFO[Container(6530).ListItem.Artist,, • ]$INFO[Container(6530).ListItem.Album,, • ]$INFO[Container(6530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.Property(StartTime))">$INFO[Container(6530).ListItem.Property(ChannelName),, • ]$INFO[Container(6530).ListItem.Property(StartTime),, - ]$INFO[Container(6530).ListItem.Property(EndTime),, • ]$INFO[Container(6530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6530).ListItem.StartTime)">$INFO[Container(6530).ListItem.ChannelName,, • ]$INFO[Container(6530).ListItem.StartTime,, - ]$INFO[Container(6530).ListItem.EndTime,, • ]$INFO[Container(6530).ListItem.Genre]</value>
+	</variable>
+	<variable name="6540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6540">
+		<value condition="String.Contains(Container(6540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6540).ListItem.label] $INFO[Container(6540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Title) + String.Contains(Container(6540).ListItem.FolderPath, pvr://)">$INFO[Container(6540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Season) + !String.IsEmpty(Container(6540).ListItem.Episode) + !String.Contains(Container(6540).ListItem.TvShowTitle,Container(6540).ListItem.Title)">[UPPERCASE]S$INFO[Container(6540).ListItem.Season]E$INFO[Container(6540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Title)">$INFO[Container(6540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Label)">$INFO[Container(6540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6540">
+		<value condition="!String.IsEmpty(Container(6540).ListItem.TvShowTitle) + !String.IsEmpty(Container(6540).ListItem.Genre)">$INFO[Container(6540).ListItem.TvShowTitle,, • ]$INFO[Container(6540).ListItem.Year,, • ]$INFO[Container(6540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.TvShowTitle)">$INFO[Container(6540).ListItem.TvShowTitle,, • ]$INFO[Container(6540).ListItem.Premiered,, • ]$INFO[Container(6540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Year)">$INFO[Container(6540).ListItem.Year,, • ]$INFO[Container(6540).ListItem.Duration,,min. • ]$INFO[Container(6540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Artist) + !String.IsEmpty(Container(6540).ListItem.Album)">$INFO[Container(6540).ListItem.Artist,, • ]$INFO[Container(6540).ListItem.Album,, • ]$INFO[Container(6540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.Property(StartTime))">$INFO[Container(6540).ListItem.Property(ChannelName),, • ]$INFO[Container(6540).ListItem.Property(StartTime),, - ]$INFO[Container(6540).ListItem.Property(EndTime),, • ]$INFO[Container(6540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6540).ListItem.StartTime)">$INFO[Container(6540).ListItem.ChannelName,, • ]$INFO[Container(6540).ListItem.StartTime,, - ]$INFO[Container(6540).ListItem.EndTime,, • ]$INFO[Container(6540).ListItem.Genre]</value>
+	</variable>
+	<variable name="6550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6550">
+		<value condition="String.Contains(Container(6550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6550).ListItem.label] $INFO[Container(6550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Title) + String.Contains(Container(6550).ListItem.FolderPath, pvr://)">$INFO[Container(6550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Season) + !String.IsEmpty(Container(6550).ListItem.Episode) + !String.Contains(Container(6550).ListItem.TvShowTitle,Container(6550).ListItem.Title)">[UPPERCASE]S$INFO[Container(6550).ListItem.Season]E$INFO[Container(6550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Title)">$INFO[Container(6550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Label)">$INFO[Container(6550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6550">
+		<value condition="!String.IsEmpty(Container(6550).ListItem.TvShowTitle) + !String.IsEmpty(Container(6550).ListItem.Genre)">$INFO[Container(6550).ListItem.TvShowTitle,, • ]$INFO[Container(6550).ListItem.Year,, • ]$INFO[Container(6550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.TvShowTitle)">$INFO[Container(6550).ListItem.TvShowTitle,, • ]$INFO[Container(6550).ListItem.Premiered,, • ]$INFO[Container(6550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Year)">$INFO[Container(6550).ListItem.Year,, • ]$INFO[Container(6550).ListItem.Duration,,min. • ]$INFO[Container(6550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Artist) + !String.IsEmpty(Container(6550).ListItem.Album)">$INFO[Container(6550).ListItem.Artist,, • ]$INFO[Container(6550).ListItem.Album,, • ]$INFO[Container(6550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.Property(StartTime))">$INFO[Container(6550).ListItem.Property(ChannelName),, • ]$INFO[Container(6550).ListItem.Property(StartTime),, - ]$INFO[Container(6550).ListItem.Property(EndTime),, • ]$INFO[Container(6550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6550).ListItem.StartTime)">$INFO[Container(6550).ListItem.ChannelName,, • ]$INFO[Container(6550).ListItem.StartTime,, - ]$INFO[Container(6550).ListItem.EndTime,, • ]$INFO[Container(6550).ListItem.Genre]</value>
+	</variable>
+	<variable name="6560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6560">
+		<value condition="String.Contains(Container(6560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6560).ListItem.label] $INFO[Container(6560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Title) + String.Contains(Container(6560).ListItem.FolderPath, pvr://)">$INFO[Container(6560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Season) + !String.IsEmpty(Container(6560).ListItem.Episode) + !String.Contains(Container(6560).ListItem.TvShowTitle,Container(6560).ListItem.Title)">[UPPERCASE]S$INFO[Container(6560).ListItem.Season]E$INFO[Container(6560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Title)">$INFO[Container(6560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Label)">$INFO[Container(6560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6560">
+		<value condition="!String.IsEmpty(Container(6560).ListItem.TvShowTitle) + !String.IsEmpty(Container(6560).ListItem.Genre)">$INFO[Container(6560).ListItem.TvShowTitle,, • ]$INFO[Container(6560).ListItem.Year,, • ]$INFO[Container(6560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.TvShowTitle)">$INFO[Container(6560).ListItem.TvShowTitle,, • ]$INFO[Container(6560).ListItem.Premiered,, • ]$INFO[Container(6560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Year)">$INFO[Container(6560).ListItem.Year,, • ]$INFO[Container(6560).ListItem.Duration,,min. • ]$INFO[Container(6560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Artist) + !String.IsEmpty(Container(6560).ListItem.Album)">$INFO[Container(6560).ListItem.Artist,, • ]$INFO[Container(6560).ListItem.Album,, • ]$INFO[Container(6560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.Property(StartTime))">$INFO[Container(6560).ListItem.Property(ChannelName),, • ]$INFO[Container(6560).ListItem.Property(StartTime),, - ]$INFO[Container(6560).ListItem.Property(EndTime),, • ]$INFO[Container(6560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6560).ListItem.StartTime)">$INFO[Container(6560).ListItem.ChannelName,, • ]$INFO[Container(6560).ListItem.StartTime,, - ]$INFO[Container(6560).ListItem.EndTime,, • ]$INFO[Container(6560).ListItem.Genre]</value>
+	</variable>
+	<variable name="6570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6570">
+		<value condition="String.Contains(Container(6570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6570).ListItem.label] $INFO[Container(6570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Title) + String.Contains(Container(6570).ListItem.FolderPath, pvr://)">$INFO[Container(6570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Season) + !String.IsEmpty(Container(6570).ListItem.Episode) + !String.Contains(Container(6570).ListItem.TvShowTitle,Container(6570).ListItem.Title)">[UPPERCASE]S$INFO[Container(6570).ListItem.Season]E$INFO[Container(6570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Title)">$INFO[Container(6570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Label)">$INFO[Container(6570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6570">
+		<value condition="!String.IsEmpty(Container(6570).ListItem.TvShowTitle) + !String.IsEmpty(Container(6570).ListItem.Genre)">$INFO[Container(6570).ListItem.TvShowTitle,, • ]$INFO[Container(6570).ListItem.Year,, • ]$INFO[Container(6570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.TvShowTitle)">$INFO[Container(6570).ListItem.TvShowTitle,, • ]$INFO[Container(6570).ListItem.Premiered,, • ]$INFO[Container(6570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Year)">$INFO[Container(6570).ListItem.Year,, • ]$INFO[Container(6570).ListItem.Duration,,min. • ]$INFO[Container(6570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Artist) + !String.IsEmpty(Container(6570).ListItem.Album)">$INFO[Container(6570).ListItem.Artist,, • ]$INFO[Container(6570).ListItem.Album,, • ]$INFO[Container(6570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.Property(StartTime))">$INFO[Container(6570).ListItem.Property(ChannelName),, • ]$INFO[Container(6570).ListItem.Property(StartTime),, - ]$INFO[Container(6570).ListItem.Property(EndTime),, • ]$INFO[Container(6570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6570).ListItem.StartTime)">$INFO[Container(6570).ListItem.ChannelName,, • ]$INFO[Container(6570).ListItem.StartTime,, - ]$INFO[Container(6570).ListItem.EndTime,, • ]$INFO[Container(6570).ListItem.Genre]</value>
+	</variable>
+	<variable name="6580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-6580">
+		<value condition="String.Contains(Container(6580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(6580).ListItem.label] $INFO[Container(6580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Title) + String.Contains(Container(6580).ListItem.FolderPath, pvr://)">$INFO[Container(6580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Season) + !String.IsEmpty(Container(6580).ListItem.Episode) + !String.Contains(Container(6580).ListItem.TvShowTitle,Container(6580).ListItem.Title)">[UPPERCASE]S$INFO[Container(6580).ListItem.Season]E$INFO[Container(6580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(6580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Title)">$INFO[Container(6580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Label)">$INFO[Container(6580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-6580">
+		<value condition="!String.IsEmpty(Container(6580).ListItem.TvShowTitle) + !String.IsEmpty(Container(6580).ListItem.Genre)">$INFO[Container(6580).ListItem.TvShowTitle,, • ]$INFO[Container(6580).ListItem.Year,, • ]$INFO[Container(6580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.TvShowTitle)">$INFO[Container(6580).ListItem.TvShowTitle,, • ]$INFO[Container(6580).ListItem.Premiered,, • ]$INFO[Container(6580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Year)">$INFO[Container(6580).ListItem.Year,, • ]$INFO[Container(6580).ListItem.Duration,,min. • ]$INFO[Container(6580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Artist) + !String.IsEmpty(Container(6580).ListItem.Album)">$INFO[Container(6580).ListItem.Artist,, • ]$INFO[Container(6580).ListItem.Album,, • ]$INFO[Container(6580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.Property(StartTime))">$INFO[Container(6580).ListItem.Property(ChannelName),, • ]$INFO[Container(6580).ListItem.Property(StartTime),, - ]$INFO[Container(6580).ListItem.Property(EndTime),, • ]$INFO[Container(6580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(6580).ListItem.StartTime)">$INFO[Container(6580).ListItem.ChannelName,, • ]$INFO[Container(6580).ListItem.StartTime,, - ]$INFO[Container(6580).ListItem.EndTime,, • ]$INFO[Container(6580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-6">
+		<value condition="Skin.String(widgetvalue-weather,7)" />
+		<value condition="Skin.String(widgetvalue-weather,6)" />
+		<value condition="Skin.String(widgetvalue-weather,5)" />
+		<value condition="Skin.String(widgetvalue-weather,4)" />
+		<value condition="Skin.String(widgetvalue-weather,3)" />
+		<value condition="Skin.String(widgetvalue-weather,2)" />
+		<value condition="Skin.String(widgetvalue-weather,1)" />
+		<value>$LOCALIZE[8]</value>
+	</variable>
+	<variable name="12510-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12510">
+		<value condition="String.Contains(Container(12510).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12510).ListItem.label] $INFO[Container(12510).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Title) + String.Contains(Container(12510).ListItem.FolderPath, pvr://)">$INFO[Container(12510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Season) + !String.IsEmpty(Container(12510).ListItem.Episode) + !String.Contains(Container(12510).ListItem.TvShowTitle,Container(12510).ListItem.Title)">[UPPERCASE]S$INFO[Container(12510).ListItem.Season]E$INFO[Container(12510).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Title)">$INFO[Container(12510).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Label)">$INFO[Container(12510).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12510">
+		<value condition="!String.IsEmpty(Container(12510).ListItem.TvShowTitle) + !String.IsEmpty(Container(12510).ListItem.Genre)">$INFO[Container(12510).ListItem.TvShowTitle,, • ]$INFO[Container(12510).ListItem.Year,, • ]$INFO[Container(12510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.TvShowTitle)">$INFO[Container(12510).ListItem.TvShowTitle,, • ]$INFO[Container(12510).ListItem.Premiered,, • ]$INFO[Container(12510).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Year)">$INFO[Container(12510).ListItem.Year,, • ]$INFO[Container(12510).ListItem.Duration,,min. • ]$INFO[Container(12510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Artist) + !String.IsEmpty(Container(12510).ListItem.Album)">$INFO[Container(12510).ListItem.Artist,, • ]$INFO[Container(12510).ListItem.Album,, • ]$INFO[Container(12510).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.Property(StartTime))">$INFO[Container(12510).ListItem.Property(ChannelName),, • ]$INFO[Container(12510).ListItem.Property(StartTime),, - ]$INFO[Container(12510).ListItem.Property(EndTime),, • ]$INFO[Container(12510).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12510).ListItem.StartTime)">$INFO[Container(12510).ListItem.ChannelName,, • ]$INFO[Container(12510).ListItem.StartTime,, - ]$INFO[Container(12510).ListItem.EndTime,, • ]$INFO[Container(12510).ListItem.Genre]</value>
+	</variable>
+	<variable name="12520-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12520">
+		<value condition="String.Contains(Container(12520).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12520).ListItem.label] $INFO[Container(12520).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Title) + String.Contains(Container(12520).ListItem.FolderPath, pvr://)">$INFO[Container(12520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Season) + !String.IsEmpty(Container(12520).ListItem.Episode) + !String.Contains(Container(12520).ListItem.TvShowTitle,Container(12520).ListItem.Title)">[UPPERCASE]S$INFO[Container(12520).ListItem.Season]E$INFO[Container(12520).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Title)">$INFO[Container(12520).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Label)">$INFO[Container(12520).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12520">
+		<value condition="!String.IsEmpty(Container(12520).ListItem.TvShowTitle) + !String.IsEmpty(Container(12520).ListItem.Genre)">$INFO[Container(12520).ListItem.TvShowTitle,, • ]$INFO[Container(12520).ListItem.Year,, • ]$INFO[Container(12520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.TvShowTitle)">$INFO[Container(12520).ListItem.TvShowTitle,, • ]$INFO[Container(12520).ListItem.Premiered,, • ]$INFO[Container(12520).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Year)">$INFO[Container(12520).ListItem.Year,, • ]$INFO[Container(12520).ListItem.Duration,,min. • ]$INFO[Container(12520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Artist) + !String.IsEmpty(Container(12520).ListItem.Album)">$INFO[Container(12520).ListItem.Artist,, • ]$INFO[Container(12520).ListItem.Album,, • ]$INFO[Container(12520).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.Property(StartTime))">$INFO[Container(12520).ListItem.Property(ChannelName),, • ]$INFO[Container(12520).ListItem.Property(StartTime),, - ]$INFO[Container(12520).ListItem.Property(EndTime),, • ]$INFO[Container(12520).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12520).ListItem.StartTime)">$INFO[Container(12520).ListItem.ChannelName,, • ]$INFO[Container(12520).ListItem.StartTime,, - ]$INFO[Container(12520).ListItem.EndTime,, • ]$INFO[Container(12520).ListItem.Genre]</value>
+	</variable>
+	<variable name="12530-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12530">
+		<value condition="String.Contains(Container(12530).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12530).ListItem.label] $INFO[Container(12530).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Title) + String.Contains(Container(12530).ListItem.FolderPath, pvr://)">$INFO[Container(12530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Season) + !String.IsEmpty(Container(12530).ListItem.Episode) + !String.Contains(Container(12530).ListItem.TvShowTitle,Container(12530).ListItem.Title)">[UPPERCASE]S$INFO[Container(12530).ListItem.Season]E$INFO[Container(12530).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Title)">$INFO[Container(12530).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Label)">$INFO[Container(12530).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12530">
+		<value condition="!String.IsEmpty(Container(12530).ListItem.TvShowTitle) + !String.IsEmpty(Container(12530).ListItem.Genre)">$INFO[Container(12530).ListItem.TvShowTitle,, • ]$INFO[Container(12530).ListItem.Year,, • ]$INFO[Container(12530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.TvShowTitle)">$INFO[Container(12530).ListItem.TvShowTitle,, • ]$INFO[Container(12530).ListItem.Premiered,, • ]$INFO[Container(12530).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Year)">$INFO[Container(12530).ListItem.Year,, • ]$INFO[Container(12530).ListItem.Duration,,min. • ]$INFO[Container(12530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Artist) + !String.IsEmpty(Container(12530).ListItem.Album)">$INFO[Container(12530).ListItem.Artist,, • ]$INFO[Container(12530).ListItem.Album,, • ]$INFO[Container(12530).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.Property(StartTime))">$INFO[Container(12530).ListItem.Property(ChannelName),, • ]$INFO[Container(12530).ListItem.Property(StartTime),, - ]$INFO[Container(12530).ListItem.Property(EndTime),, • ]$INFO[Container(12530).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12530).ListItem.StartTime)">$INFO[Container(12530).ListItem.ChannelName,, • ]$INFO[Container(12530).ListItem.StartTime,, - ]$INFO[Container(12530).ListItem.EndTime,, • ]$INFO[Container(12530).ListItem.Genre]</value>
+	</variable>
+	<variable name="12540-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12540">
+		<value condition="String.Contains(Container(12540).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12540).ListItem.label] $INFO[Container(12540).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Title) + String.Contains(Container(12540).ListItem.FolderPath, pvr://)">$INFO[Container(12540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Season) + !String.IsEmpty(Container(12540).ListItem.Episode) + !String.Contains(Container(12540).ListItem.TvShowTitle,Container(12540).ListItem.Title)">[UPPERCASE]S$INFO[Container(12540).ListItem.Season]E$INFO[Container(12540).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Title)">$INFO[Container(12540).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Label)">$INFO[Container(12540).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12540">
+		<value condition="!String.IsEmpty(Container(12540).ListItem.TvShowTitle) + !String.IsEmpty(Container(12540).ListItem.Genre)">$INFO[Container(12540).ListItem.TvShowTitle,, • ]$INFO[Container(12540).ListItem.Year,, • ]$INFO[Container(12540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.TvShowTitle)">$INFO[Container(12540).ListItem.TvShowTitle,, • ]$INFO[Container(12540).ListItem.Premiered,, • ]$INFO[Container(12540).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Year)">$INFO[Container(12540).ListItem.Year,, • ]$INFO[Container(12540).ListItem.Duration,,min. • ]$INFO[Container(12540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Artist) + !String.IsEmpty(Container(12540).ListItem.Album)">$INFO[Container(12540).ListItem.Artist,, • ]$INFO[Container(12540).ListItem.Album,, • ]$INFO[Container(12540).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.Property(StartTime))">$INFO[Container(12540).ListItem.Property(ChannelName),, • ]$INFO[Container(12540).ListItem.Property(StartTime),, - ]$INFO[Container(12540).ListItem.Property(EndTime),, • ]$INFO[Container(12540).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12540).ListItem.StartTime)">$INFO[Container(12540).ListItem.ChannelName,, • ]$INFO[Container(12540).ListItem.StartTime,, - ]$INFO[Container(12540).ListItem.EndTime,, • ]$INFO[Container(12540).ListItem.Genre]</value>
+	</variable>
+	<variable name="12550-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12550">
+		<value condition="String.Contains(Container(12550).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12550).ListItem.label] $INFO[Container(12550).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Title) + String.Contains(Container(12550).ListItem.FolderPath, pvr://)">$INFO[Container(12550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Season) + !String.IsEmpty(Container(12550).ListItem.Episode) + !String.Contains(Container(12550).ListItem.TvShowTitle,Container(12550).ListItem.Title)">[UPPERCASE]S$INFO[Container(12550).ListItem.Season]E$INFO[Container(12550).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Title)">$INFO[Container(12550).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Label)">$INFO[Container(12550).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12550">
+		<value condition="!String.IsEmpty(Container(12550).ListItem.TvShowTitle) + !String.IsEmpty(Container(12550).ListItem.Genre)">$INFO[Container(12550).ListItem.TvShowTitle,, • ]$INFO[Container(12550).ListItem.Year,, • ]$INFO[Container(12550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.TvShowTitle)">$INFO[Container(12550).ListItem.TvShowTitle,, • ]$INFO[Container(12550).ListItem.Premiered,, • ]$INFO[Container(12550).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Year)">$INFO[Container(12550).ListItem.Year,, • ]$INFO[Container(12550).ListItem.Duration,,min. • ]$INFO[Container(12550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Artist) + !String.IsEmpty(Container(12550).ListItem.Album)">$INFO[Container(12550).ListItem.Artist,, • ]$INFO[Container(12550).ListItem.Album,, • ]$INFO[Container(12550).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.Property(StartTime))">$INFO[Container(12550).ListItem.Property(ChannelName),, • ]$INFO[Container(12550).ListItem.Property(StartTime),, - ]$INFO[Container(12550).ListItem.Property(EndTime),, • ]$INFO[Container(12550).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12550).ListItem.StartTime)">$INFO[Container(12550).ListItem.ChannelName,, • ]$INFO[Container(12550).ListItem.StartTime,, - ]$INFO[Container(12550).ListItem.EndTime,, • ]$INFO[Container(12550).ListItem.Genre]</value>
+	</variable>
+	<variable name="12560-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12560">
+		<value condition="String.Contains(Container(12560).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12560).ListItem.label] $INFO[Container(12560).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Title) + String.Contains(Container(12560).ListItem.FolderPath, pvr://)">$INFO[Container(12560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Season) + !String.IsEmpty(Container(12560).ListItem.Episode) + !String.Contains(Container(12560).ListItem.TvShowTitle,Container(12560).ListItem.Title)">[UPPERCASE]S$INFO[Container(12560).ListItem.Season]E$INFO[Container(12560).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Title)">$INFO[Container(12560).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Label)">$INFO[Container(12560).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12560">
+		<value condition="!String.IsEmpty(Container(12560).ListItem.TvShowTitle) + !String.IsEmpty(Container(12560).ListItem.Genre)">$INFO[Container(12560).ListItem.TvShowTitle,, • ]$INFO[Container(12560).ListItem.Year,, • ]$INFO[Container(12560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.TvShowTitle)">$INFO[Container(12560).ListItem.TvShowTitle,, • ]$INFO[Container(12560).ListItem.Premiered,, • ]$INFO[Container(12560).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Year)">$INFO[Container(12560).ListItem.Year,, • ]$INFO[Container(12560).ListItem.Duration,,min. • ]$INFO[Container(12560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Artist) + !String.IsEmpty(Container(12560).ListItem.Album)">$INFO[Container(12560).ListItem.Artist,, • ]$INFO[Container(12560).ListItem.Album,, • ]$INFO[Container(12560).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.Property(StartTime))">$INFO[Container(12560).ListItem.Property(ChannelName),, • ]$INFO[Container(12560).ListItem.Property(StartTime),, - ]$INFO[Container(12560).ListItem.Property(EndTime),, • ]$INFO[Container(12560).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12560).ListItem.StartTime)">$INFO[Container(12560).ListItem.ChannelName,, • ]$INFO[Container(12560).ListItem.StartTime,, - ]$INFO[Container(12560).ListItem.EndTime,, • ]$INFO[Container(12560).ListItem.Genre]</value>
+	</variable>
+	<variable name="12570-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12570">
+		<value condition="String.Contains(Container(12570).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12570).ListItem.label] $INFO[Container(12570).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Title) + String.Contains(Container(12570).ListItem.FolderPath, pvr://)">$INFO[Container(12570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Season) + !String.IsEmpty(Container(12570).ListItem.Episode) + !String.Contains(Container(12570).ListItem.TvShowTitle,Container(12570).ListItem.Title)">[UPPERCASE]S$INFO[Container(12570).ListItem.Season]E$INFO[Container(12570).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Title)">$INFO[Container(12570).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Label)">$INFO[Container(12570).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12570">
+		<value condition="!String.IsEmpty(Container(12570).ListItem.TvShowTitle) + !String.IsEmpty(Container(12570).ListItem.Genre)">$INFO[Container(12570).ListItem.TvShowTitle,, • ]$INFO[Container(12570).ListItem.Year,, • ]$INFO[Container(12570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.TvShowTitle)">$INFO[Container(12570).ListItem.TvShowTitle,, • ]$INFO[Container(12570).ListItem.Premiered,, • ]$INFO[Container(12570).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Year)">$INFO[Container(12570).ListItem.Year,, • ]$INFO[Container(12570).ListItem.Duration,,min. • ]$INFO[Container(12570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Artist) + !String.IsEmpty(Container(12570).ListItem.Album)">$INFO[Container(12570).ListItem.Artist,, • ]$INFO[Container(12570).ListItem.Album,, • ]$INFO[Container(12570).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.Property(StartTime))">$INFO[Container(12570).ListItem.Property(ChannelName),, • ]$INFO[Container(12570).ListItem.Property(StartTime),, - ]$INFO[Container(12570).ListItem.Property(EndTime),, • ]$INFO[Container(12570).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12570).ListItem.StartTime)">$INFO[Container(12570).ListItem.ChannelName,, • ]$INFO[Container(12570).ListItem.StartTime,, - ]$INFO[Container(12570).ListItem.EndTime,, • ]$INFO[Container(12570).ListItem.Genre]</value>
+	</variable>
+	<variable name="12580-refresh">
+		<value condition="!String.IsEmpty(Window(Home).property(skinhelper-refreshvideowidgetsbusy))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="!String.IsEmpty(Window(Home).property(favwidgetrefresh))">special://skin/extras/emptywidget.xsp</value>
+		<value condition="window.isactive(fullscreenvideo)">special://skin/extras/emptywidget.xsp</value>
+		<value />
+	</variable>
+	<variable name="widgetinfolabel-12580">
+		<value condition="String.Contains(Container(12580).ListItem.Property(DBTYPE), systeminfo)">$INFO[Container(12580).ListItem.label] $INFO[Container(12580).ListItem.label2]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Title) + String.Contains(Container(12580).ListItem.FolderPath, pvr://)">$INFO[Container(12580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Season) + !String.IsEmpty(Container(12580).ListItem.Episode) + !String.Contains(Container(12580).ListItem.TvShowTitle,Container(12580).ListItem.Title)">[UPPERCASE]S$INFO[Container(12580).ListItem.Season]E$INFO[Container(12580).ListItem.Episode]:[/UPPERCASE] $INFO[Container(12580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Title)">$INFO[Container(12580).ListItem.Title]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Label)">$INFO[Container(12580).ListItem.Label]</value>
+	</variable>
+	<variable name="widgetsubtitle-12580">
+		<value condition="!String.IsEmpty(Container(12580).ListItem.TvShowTitle) + !String.IsEmpty(Container(12580).ListItem.Genre)">$INFO[Container(12580).ListItem.TvShowTitle,, • ]$INFO[Container(12580).ListItem.Year,, • ]$INFO[Container(12580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.TvShowTitle)">$INFO[Container(12580).ListItem.TvShowTitle,, • ]$INFO[Container(12580).ListItem.Premiered,, • ]$INFO[Container(12580).ListItem.Duration,,min.]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Year)">$INFO[Container(12580).ListItem.Year,, • ]$INFO[Container(12580).ListItem.Duration,,min. • ]$INFO[Container(12580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Artist) + !String.IsEmpty(Container(12580).ListItem.Album)">$INFO[Container(12580).ListItem.Artist,, • ]$INFO[Container(12580).ListItem.Album,, • ]$INFO[Container(12580).ListItem.Duration]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.Property(StartTime))">$INFO[Container(12580).ListItem.Property(ChannelName),, • ]$INFO[Container(12580).ListItem.Property(StartTime),, - ]$INFO[Container(12580).ListItem.Property(EndTime),, • ]$INFO[Container(12580).ListItem.Genre]</value>
+		<value condition="!String.IsEmpty(Container(12580).ListItem.StartTime)">$INFO[Container(12580).ListItem.ChannelName,, • ]$INFO[Container(12580).ListItem.StartTime,, - ]$INFO[Container(12580).ListItem.EndTime,, • ]$INFO[Container(12580).ListItem.Genre]</value>
+	</variable>
+	<variable name="widgetlabel-12">
+		<value condition="Skin.String(widgetvalue-settings,7)" />
+		<value condition="Skin.String(widgetvalue-settings,6)" />
+		<value condition="Skin.String(widgetvalue-settings,5)" />
+		<value condition="Skin.String(widgetvalue-settings,4)" />
+		<value condition="Skin.String(widgetvalue-settings,3)" />
+		<value condition="Skin.String(widgetvalue-settings,2)" />
+		<value condition="Skin.String(widgetvalue-settings,1)" />
+		<value>$LOCALIZE[130]</value>
+	</variable>
+</includes>


### PR DESCRIPTION
checked

- viewtype labels : correct, no double usage
- checked include call: correct, if disabled dont load it (ren Window.IsActive(*) 'MyVideoNav.xml' to 'videos') in IncludesViews.xml

- changed/add include hiddenObject in Includes.xml
		<itemlayout height="10" width="10" />
		<focusedlayout height="10" width="10" />

	! VIELLEICHT IM GENERELLEN MAL ÜBERPRÜFEN UND DIFFERENZIEREN - WO die Include benutzt wird und 2 includes erstellen

	hidden object - wenn versteckter BUTTON - dann keine tags benutzen welche nicht dafür vorgesen sind - z.b. <itemlayout /> <focusedlayout />
	hidden container - wenn versteckter Container - dann keine Tags benutzen welche dafür nicht vorgesehen sind - z.b. <texturefocus /> <texturenofocus />

View_529_NetflixSeasons.xml
- moved main container for readability
- content cast : switch to use db id
- added content variabels for each custom content containers

		!!
		- add last 2 lines which is just for debugging

			- <value condition="Control.IsVisible(529)">view_529_Content_Similiar_should_BE_VISIBLE_IN_IF_VIEW529_VISBLE</value>
			  <value>view_529_Content_Similiar_is_called_but_IT_SHOULDNT</value>

			- check log file for ... "ERROR <general>: XFILE::CDirectory::GetDirectory - Error getting" + should_BE_VISIBLE_IN_IF_VIEW529_VISBLE
			 and check when it tries to load the content, it seems visible conditions in the container which uses variable content doesnt matter, <content> is loaded in background to have it available !!!

						!!!

			- DELETE THESE LAST TWO LINES IN THE CONTENT VARIABLE BEFORE BUILD NEW VERSION ZIP FILE or after testing and lookup logs

						!!!!

			NOTE: EVEN IF

				```
	<control type="group">
						<visible>Control.IsVisible(529)</visible>

						<control type="list" id="529">
							<description>view container</description>
							<include>HiddenObject</include>
							<visible>Container.Content(seasons) + [Integer.IsEqual(Window(Home).Property(SkinHelper.ForcedView),529) | String.IsEmpty(Window(Home).Property(SkinHelper.ForcedView))]</visible>
							<viewtype label="31902">Netflix Info</viewtype>
						</control>
						<control type="list" id="529**1">
							<visible>Control.IsVisible(529)</visible>
							<description>custom container blong to current view</description>
							<content target="videos">$VAR[1***]</content>
						</control>
						<control type="list" id="529**2">
							<visible>Control.IsVisible(529)</visible>
							<description>custom container blong to current view</description>
							<content target="videos">$VAR[2***]</content>
						</control>
					</control>

							<variable name="529**">
								<value condition="Control.IsVisible(529)">view_529_Content__should_BE_VISIBLE_IF_VIEW529_VISBLE</value>
								<value>view_529_Content__is_called_but_IT_SHOULDNT</value>
							</variable>
```

					- the content is loaded, seems trhat (control.isvisible(**) is ignored for any custom content container if in media window viewtypes )

						-> therefore tried a workaraound with the belonging viewtype label

					instead of Control.IsVisible(529) use String.IsEqual(Container.ViewMode,$LOCALIZE[31902])