### PR TITLE
Artwork downloader support

### DIFF
--- a/1080i/IncludesDialogMusicInfo.xml
+++ b/1080i/IncludesDialogMusicInfo.xml
@@ -904,29 +904,41 @@
 				<align>center</align>
 				<label>Get Song Thumb</label>
 			</control> -->
+			<control type="button" id="14">
+			  <!-- 8 	free id ? - button 	artwork downloader select artwork -->
+				<height>60</height>
+				<width>300</width>
+				<label>AD:Select Artwork</label> 
+				<textoffsetx>15</textoffsetx>
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<description>Get Artwork</description>
+				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.downloader)</visible>
+			</control>            
 			<control type="button" id="8">
 			  <!-- 8 	free id ? - button 	artwork beef select artwork -->
 				<height>60</height>
 				<width>300</width>
 				<label>AB:Select Artwork</label> 
 				<textoffsetx>15</textoffsetx>
-				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
 				<description>Get Artwork</description>
 				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.beef)</visible>
 			</control>
 			<control type="button" id="9">
-			  <!-- 9 	free id ? - button 	artwork beef dl all artwork -->
+			  <!-- 9 	free id ? - button 	artwork downloader dl all artwork -->
 				<height>60</height>
 				<width>300</width>
 				<label>AB:DL All Artwork</label>
 				<textoffsetx>15</textoffsetx>
-				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
 				<description>Get Artwork</description>
-				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.beef)</visible>
+				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.downloader)</visible>
 			</control>
 			<control type="button" id="7">
 			  <!-- 7 	button 	User rating -->
@@ -1274,24 +1286,34 @@
 			  <label>13405</label>
 			  <enable>!Skin.HasSetting(KioskMode.Enabled)</enable>
 			</control>
+			<!-- artwork downloader -->
+			 <control type="button" id="14">
+				<label>AB:Select Artwork</label>           
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<description>Get Artwork</description>
+				<include>DialogButtonOther</include>
+				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.downloader)</visible>
+			</control>            
 			<!-- artwork beef -->
 			 <control type="button" id="8">
 				<label>AB:Select Artwork</label>           
-				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
 				<description>Get Artwork</description>
 				<include>DialogButtonOther</include>
 				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.beef)</visible>
 			</control>
 			<control type="button" id="9">
 				<label>AB:DL All Artwork</label>
-				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,artist) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,album) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBType,song) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
 				<description>Get Artwork</description>
 				<include>DialogButtonOther</include>
-				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.beef)</visible>
+				<visible>[String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song) | String.IsEqual(ListItem.DBType,artist)] + system.hasaddon(script.artwork.downloader)</visible>
 			</control>
 			
 			

--- a/1080i/IncludesDialogVideoInfo.xml
+++ b/1080i/IncludesDialogVideoInfo.xml
@@ -469,7 +469,7 @@
 					<usealttexture>Player.HasVideo</usealttexture>
 					<onclick condition="!String.IsEmpty(Window(home).Property(trailer_avail))">PlayMedia($INFO[Window(Home).Property(filename_formatted)]$INFO[ListItem.Title,,-trailer.mp4],1)</onclick>
 					<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + String.IsEqual(ListItem.DBTYPE,movie)">Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) -->    
-					<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtraileryoutube,title=$INFO[ListItem.Title],local=true)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) -->
+					<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtrailer,title=$INFO[ListItem.Title],local=true)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) -->
 					<onup condition="Player.HasVideo">Stop</onup>
 					<ondown condition="Player.HasVideo">Stop</ondown>    												
 					<onclick condition="Player.HasVideo">FullScreen</onclick>
@@ -494,11 +494,14 @@
 					<align>center</align>
 					<textoffsetx>0</textoffsetx>
 					<visible>Skin.HasSetting(videoinfo_button_extendedinfo)</visible>
-					<onclick condition="!System.HasAddon(script.extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
-					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
-					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
-					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
-					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+					<onclick condition="!System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
+					<onclick condition="!System.HasAddon(script.embuary.info) + String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo)">RunPlugin(plugin://script.embuary.info)</onclick>
+					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
+					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
+					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
+					<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+					<onclick condition="String.IsEmpty(ListItem.TvShowTitle) + [String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)]">RunScript(script.embuary.info,call=movie,query='"$INFO[ListItem.Label]"',year=$INFO[ListItem.Year])</onclick>
+					<onclick condition="!String.IsEmpty(ListItem.TvShowTitle) + [String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)]">RunScript(script.embuary.info,call=tv,query='"$INFO[ListItem.TvShowTitle]"')</onclick>
 				</control>
 				
 				<control type="button" id="7">
@@ -522,6 +525,21 @@
 					<visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
 					<visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
 				</control>
+				<!-- Artwork Downloader -->
+				<control type="button" id="105">
+					<!--Get Thumb Artwork Downloader--> 
+					<label>Artwork Downloader</label>
+					<width>285</width>
+					<height>40</height>
+					<align>center</align>
+					<textoffsetx>0</textoffsetx>
+					<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+					<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+					<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+					<description>Get Artwork</description>
+					<visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + system.hasaddon(script.artwork.downloader)</visible>
+					<visible>Skin.HasSetting(videoinfo_button_artworkdownloader)</visible>
+				</control>                
 				<!-- Artwork Beef -->
 				<control type="button" id="104">
 					<!--Get Thumb Artwork Beef--> 
@@ -530,9 +548,9 @@
 					<height>40</height>
 					<align>center</align>
 					<textoffsetx>0</textoffsetx>
-					<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-					<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-					<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+					<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+					<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+					<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
 					<description>Get Artwork</description>
 					<visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + system.hasaddon(script.artwork.beef)</visible>
 					<visible>Skin.HasSetting(videoinfo_button_artworkbeef)</visible>
@@ -706,6 +724,7 @@
 					<param name="visible" value="Integer.IsGreater(Container(8601).NumItems,0) | Container(8601).IsUpdating" />
 					<animation effect="fade" start="100" end="0" condition="!Integer.IsGreater(Container(8601).NumItems,0) | Container(8601).IsUpdating">Conditional</animation>
 					<content>$VAR[EmbuaryCast]</content>
+					<include>VideoInfo_CastAction</include>
 				</include>
 				
 				<!-- ITEMS BY CAST ,including current video
@@ -784,10 +803,10 @@
 					<param name="width" value="578" />
 					<param name="height" value="340" />
 					<param name="layout" value="ThumbsViewLayout" />
-					<param name="visible" value="[System.HasNetwork + System.HasAddon(plugin.video.youtube)] + [Integer.IsGreater(Container(8605).NumItems,0) | Container(8605).IsUpdating]" />
+					<param name="visible" value="[!Skin.HasSetting(YoutubeNoOnlineLookup) + System.HasNetwork + System.HasAddon(plugin.video.youtube)] + [Integer.IsGreater(Container(8605).NumItems,0) | Container(8605).IsUpdating]" />
 					<animation effect="fade" start="100" end="0" condition="!Integer.IsGreater(Container(8605).NumItems,0) | Container(8605).IsUpdating">Conditional</animation>
 					<onclick>PlayMedia($INFO[Container(8605).ListItem.FileNameAndPath])</onclick>
-					<content target="videos" sortby="file" limit="4">plugin://plugin.video.youtube/search/?q=$VAR[tvShowsearch]</content>
+					<content target="videos" sortby="file" limit="4">$VAR[No_Youtube_search]</content>
 				</include>
 				
 				<!-- stored extra fanart $LOCALIZE[20438]-->
@@ -1491,7 +1510,7 @@
 							<usealttexture>Player.HasVideo</usealttexture>
 							<onclick condition="!String.IsEmpty(Window(home).Property(trailer_avail))">PlayMedia($INFO[Window(Home).Property(filename_formatted)]$INFO[ListItem.Title,,-trailer.mp4],1)</onclick>
 							<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + String.IsEqual(ListItem.DBTYPE,movie)">Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) -->    
-							<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtraileryoutube,title=$INFO[ListItem.Title],local=true)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) --> 
+							<onclick condition="String.IsEmpty(Window(home).Property(trailer_avail)) + !Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtrailer,title=$INFO[ListItem.Title],local=true)</onclick> <!--sometimes huge delay Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1) ,faster but dont get all  PlayMedia($INFO[ListItem.Trailer],1) --> 
 							<onup condition="Player.HasVideo">Stop</onup>
 							<ondown condition="Player.HasVideo">Stop</ondown>   												
 							<onclick condition="Player.HasVideo">FullScreen</onclick>
@@ -1582,12 +1601,15 @@
 							<height>40</height>
 							<align>center</align>
 							<textoffsetx>0</textoffsetx>
-							<visible>Skin.HasSetting(videoinfo_button_extendedinfo)</visible>
-							<onclick condition="!System.HasAddon(script.extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
-							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
-							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
-							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
-							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+							<visible>true</visible>
+							<onclick condition="!System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
+							<onclick condition="!System.HasAddon(script.embuary.info) + String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo)">RunPlugin(plugin://script.embuary.info)</onclick>
+							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
+							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
+							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
+							<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+							<onclick condition="String.IsEmpty(ListItem.TvShowTitle) + [String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)]">RunScript(script.embuary.info,call=movie,query='"$INFO[ListItem.Label]"',year=$INFO[ListItem.Year])</onclick>
+							<onclick condition="!String.IsEmpty(ListItem.TvShowTitle) + [String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)]">RunScript(script.embuary.info,call=tv,query='"$INFO[ListItem.TvShowTitle]"')</onclick>
 						</control>
 						<control type="button" id="112">
 							 <width>285</width>
@@ -1611,7 +1633,7 @@
 						</control>
 						
 						<control type="button" id="10">
-							<!--Get Thumb Artwork Downloader--> <!-- replace with Artwork Beef -->
+							<!--Get Thumb Artwork Downloader-->
 							<label>13511</label>
 							<width>285</width>
 							<height>40</height>
@@ -1619,6 +1641,24 @@
 							<textoffsetx>0</textoffsetx>
 							<visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
 							<visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
+							<visible>String.IsEmpty(Window.Property(AdditionalInfo))</visible>
+						</control>
+
+						<!-- Artwork Downloader -->
+						<control type="button" id="105">
+							<!--Get Thumb Artwork Downloader--> 
+							<label>Artwork Downloader</label>
+							<width>285</width>
+							<height>40</height>
+							<align>center</align>
+							<textoffsetx>0</textoffsetx>
+							<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+							<description>Get Artwork</description>
+							<visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + system.hasaddon(script.artwork.downloader)</visible>
+							<visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
+							<visible>Skin.HasSetting(videoinfo_button_artworkdownloader)</visible>
 							<visible>String.IsEmpty(Window.Property(AdditionalInfo))</visible>
 						</control>
 						
@@ -1630,9 +1670,9 @@
 							<height>40</height>
 							<align>center</align>
 							<textoffsetx>0</textoffsetx>
-							<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-							<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-							<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
 							<description>Get Artwork</description>
 							<visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + system.hasaddon(script.artwork.beef)</visible>
 							<visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
@@ -2289,6 +2329,8 @@
 								<left>695</left>
 								<include>AltRatingMovieInfo</include>
 								<animation effect="slide" end="0,270" center="auto" time="0" condition="String.IsEqual(ListItem.DBType,tvshow) + !Skin.String(mediaflagsstyle,disabled)">Conditional</animation>
+								<!--animation effect="slide" end="150,265" center="auto" time="0" condition="Skin.String(mediaflagsstyle,disabled)">Conditional</animation>
+								<!--animation effect="slide" end="350,265" center="auto" time="0" condition="String.IsEqual(ListItem.DBType,episode) + !Skin.String(mediaflagsstyle,disabled)">Conditional</animation-->
 								<visible>!Player.HasVideo</visible>
 							</control>
 							<!-- NEW dividing line -->
@@ -2675,7 +2717,7 @@
 
                 <!-- hidden my rating button -->
                 <control type="button" id="7">
-                    <include>HiddenButton</include>
+                    <include>HiddenObject</include>
                 </control>
 
 				<!-- spotlight previewwindow section right -->
@@ -3329,8 +3371,8 @@
 								<usealttexture>Player.HasVideo</usealttexture>
 								<onclick condition="!String.IsEmpty(Window(home).Property(trailer_avail))">PlayMedia($INFO[Window(Home).Property(filename_formatted)]$INFO[ListItem.Title,,-trailer.mp4],1)</onclick>
 								<onclick condition="!Player.HasVideo + String.IsEqual(ListItem.DBTYPE,movie)">Playmedia($INFO[Window(Home).Property(SkinHelper.ListItem.Trailer)],1)</onclick>	
-								<onclick condition="!Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtraileryoutube,title=$INFO[ListItem.Title],local=true)</onclick>  							
-								<onclick condition="!Player.HasVideo + [String.IsEmpty(ListItem.Trailer) + String.IsEqual(ListItem.DBTYPE,movie)]">RunScript(script.skin.helper.service,action=playtraileryoutube,title=$INFO[ListItem.Title],local=true)</onclick>								
+								<onclick condition="!Player.HasVideo + !String.IsEqual(ListItem.DBTYPE,movie)">RunScript(script.skin.helper.service,action=playtrailer,title=$INFO[ListItem.Title],local=true)</onclick>  							
+								<onclick condition="!Player.HasVideo + [String.IsEmpty(ListItem.Trailer) + String.IsEqual(ListItem.DBTYPE,movie)]">RunScript(script.skin.helper.service,action=playtrailer,title=$INFO[ListItem.Title],local=true)</onclick>								
 								<onclick condition="Player.HasVideo">FullScreen</onclick>
 								<onclick condition="Player.HasVideo">SetProperty(BaseWindow,InfoDialog,Home)</onclick>
                                 <onclick condition="Player.HasVideo">SetProperty(TrailerPlaying,fullscreen,home)</onclick>
@@ -3537,11 +3579,14 @@
                                 <radioposx>13</radioposx>
                                 <radiowidth>25</radiowidth>
                                 <radioheight>28</radioheight>
-                                <onclick condition="!System.HasAddon(script.extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
-                                <onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
-                                <onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
-                                <onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
-                                <onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+                                <onclick condition="!System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
+								<onclick condition="!System.HasAddon(script.embuary.info) + String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo)">RunPlugin(plugin://script.embuary.info)</onclick>
+								<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),movies)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onclick>
+								<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),tvshows)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TvShowTitle])</onclick>
+								<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],silent=True)</onclick>
+								<onclick condition="System.HasAddon(script.extendedinfo) + String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo) + String.IsEqual(Window(Home).Property(contenttype),episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,dbid=$INFO[ListItem.DBID],tvshow=$INFO[ListItem.TvShowTitle],season=$INFO[ListItem.Season],episode=$INFO[ListItem.Episode],silent=True)</onclick>
+								<onclick condition="[String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)] + String.IsEmpty(ListItem.TvShowTitle)">RunScript(script.embuary.info,call=movie,query='"$INFO[ListItem.Label]"',year=$INFO[ListItem.Year])</onclick>
+								<onclick condition="[String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo) | String.IsEqual(Skin.String(videoinfo_castaction),library_search)] + !String.IsEmpty(ListItem.TvShowTitle)">RunScript(script.embuary.info,call=tv,query='"$INFO[ListItem.TvShowTitle]"')</onclick>
                             </control>
 
                             <!-- Cinemavision button -->
@@ -3566,6 +3611,37 @@
                                 <description>CinemaVision</description>
                                 <onclick>close</onclick>
                                 <onclick>RunScript(script.cinemavision,experience)</onclick>
+                            </control>
+
+                            <!-- Artwork Downloader -->
+                            <control type="radiobutton" id="105">
+                                <visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode)] + system.hasaddon(script.artwork.downloader)</visible>
+                                <visible>!Skin.HasSetting(KioskMode.Enabled)</visible>
+                                <visible>String.IsEmpty(Window.Property(AdditionalInfo))</visible>
+                                <description>Get Artwork</description>
+                                <width>550</width>
+                                <height>65</height>
+                                <aligny>center</aligny>
+                                <align>left</align>
+                                <textoffsetx>50</textoffsetx>
+                                <textoffsety>8</textoffsety>
+                                <font>Reg30</font>
+                                <textcolor>$INFO[Skin.String(NetflixPrimaryTextColor)]</textcolor>
+                                <focusedcolor>$INFO[Skin.String(NetflixPrimaryTextColor)]</focusedcolor>
+                                <label>13511</label>
+                                <texturefocus colordiffuse="$INFO[Skin.String(NetflixPrimaryTextColor)]">netflix/border_netflix.png</texturefocus>
+                                <texturenofocus></texturenofocus>
+                                <textureradioonfocus colordiffuse="$INFO[Skin.String(NetflixPrimaryTextColor)]">netflix/text-bg-color.png</textureradioonfocus>
+                                <textureradioofffocus colordiffuse="$INFO[Skin.String(NetflixPrimaryTextColor)]">netflix/text-bg-color.png</textureradioofffocus>
+                                <textureradioonnofocus colordiffuse="$INFO[Skin.String(NetflixPrimaryTextColor)]">netflix/text-bg-color.png</textureradioonnofocus>
+                                <textureradiooffnofocus colordiffuse="$INFO[Skin.String(NetflixPrimaryTextColor)]">netflix/text-bg-color.png</textureradiooffnofocus>
+                                <radioposx>15</radioposx>
+                                <radiowidth>20</radiowidth>
+                                <radioheight>25</radioheight>
+                                <visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
+                                <onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+                                <onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                                <onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.downloader)">RunScript(script.artwork.downloader, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
                             </control>
 
                             <!-- Artwork Beef -->
@@ -3594,9 +3670,9 @@
                                 <radiowidth>20</radiowidth>
                                 <radioheight>25</radioheight>
                                 <visible>Skin.HasSetting(videoinfo_button_artwork)</visible>
-                                <onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-                                <onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-                                <onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+                                <onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+                                <onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                                <onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
                             </control>
 
                             <!--Refresh-->
@@ -4138,6 +4214,7 @@
 		<onclick condition="String.IsEqual(Skin.String(videoinfo_castaction),library_search)">ActivateWindow(1100),return</onclick>
 		<!-- <onclick condition="String.IsEqual(Skin.String(videoinfo_castaction),global_search)">Dialog.Close(movieinformation,true)</onclick> -->
 		<onclick condition="String.IsEqual(Skin.String(videoinfo_castaction),extendedinfo)">RunScript(script.extendedinfo,info=extendedactorinfo,name=$INFO[ListItem.Label])</onclick>
+		<onclick condition="String.IsEqual(Skin.String(videoinfo_castaction),embuaryinfo)">RunScript(script.embuary.info,call=person,query='"$INFO[ListItem.Label]"')</onclick>
 	</include>
 	<variable name="Similiar_Content">
 		<value condition="String.IsEqual(ListItem.DBType,movie) + !String.IsEmpty(ListItem.DBID)">plugin://script.embuary.helper/?info=getsimilar&amp;dbid=$INFO[ListItem.DBID]&amp;type=movie</value>
@@ -4150,6 +4227,9 @@
 		<value condition="String.IsEqual(Window(Home).Property(contenttype),tvshows) | String.IsEqual(Window(Home).Property(contenttype),seasons)">$VAR[EncodedTitle] $LOCALIZE[20364] $LOCALIZE[20410] $INFO[System.Language]</value>
 		<value condition="String.IsEqual(Window(Home).Property(contenttype),movie)">$VAR[EncodedTitle] $LOCALIZE[20410] $INFO[System.Language]</value>
         <value>$VAR[EncodedTitle]</value>
+	</variable>
+	<variable name="No_Youtube_search">
+		<value condition="!$EXP[IsOfflineMode] + System.HasAddon(plugin.video.youtube) + !Skin.HasSetting(YoutubeNoOnlineLookup)">plugin://plugin.video.youtube/search/?q=$VAR[tvShowsearch]</value>
 	</variable>
 	
 </includes>

--- a/1080i/‏‏‏‏IncludesSkinSetings.xml
+++ b/1080i/‏‏‏‏IncludesSkinSetings.xml
@@ -1,0 +1,3719 @@
+<?xml version="1.0" encoding="utf-8"?>
+<includes>
+    <include name="SkinSettings_HomeLayout">
+        <!--home menu layout-->
+        <control type="grouplist" id="23000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>23000</onup>
+            <ondown>23000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>311</onright>
+            <pagecontrol>311</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),12)</visible>
+            <control type="label" id="23001">
+                <include>SkinSettings_Header</include>
+                <label>31115</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <!-- homemenu layout-->
+            <control type="button" id="423003">
+                <include>SkinSettings_Button</include>
+                <label>31115</label>
+                <label2>$INFO[Skin.String(HomeLayout.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=HomeLayout,header=$LOCALIZE[31124])</onclick>
+				<onclick condition="Skin.HasSetting(AutoShowWidgets)">Skin.ToggleSetting(AutoShowWidgets)</onclick>
+				<!--onclick condition="![Skin.String(HomeLayout,1small) | Skin.String(HomeLayout,2small) | Skin.String(HomeLayout,3small)] + Skin.String(SubmenuLayout, vertical)">RunScript(script.skin.helper.service,action=setskinconstant,setting=SubmenuLayout,header=$LOCALIZE[31314])</onclick-->
+            </control>
+            <!-- height of the tiles-->
+            <control type="button" id="31770">
+                <include>SkinSettings_Button</include>
+                <label>31770</label>
+                <label2>$INFO[Skin.String(verthome_tiles_height)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinconstant,setting=verthome_tiles_height,header=$LOCALIZE[31770])</onclick>
+                <visible>Skin.String(HomeLayout,simplever_tiles)</visible>
+            </control>
+            <!--submenu after widgets on win10 home-->
+            <control type="radiobutton" id="31774">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31774]</label>
+                <onclick>Skin.ToggleSetting(Win10SubmenuRight)</onclick>
+                <visible>Skin.String(HomeLayout, Win10)</visible>
+                <selected>Skin.HasSetting(Win10SubmenuRight)</selected>
+            </control>
+            <!--fixed focus home panel-->
+            <control type="radiobutton" id="23018">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31240]</label>
+                <onclick>Skin.ToggleSetting(UseFixedHomeFocus)</onclick>
+                <selected>Skin.HasSetting(UseFixedHomeFocus)</selected>
+                <visible>![Skin.HasSetting(UseSingleShortcut) + Skin.String(HomeLayout, simplehor)]</visible>
+                <visible>Skin.String(HomeLayout, enhanced) | Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 1small) | [Skin.String(HomeLayout, simplehor) + !Skin.HasSetting(EnhancedHome_Circular)] | [String.Contains(Skin.String(HomeLayout), lowhorizontal) + !Skin.HasSetting(EnhancedHome_Circular)]</visible>
+            </control>
+            <!--single menu item-->
+            <control type="radiobutton" id="131721">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31721]</label>
+                <onclick>Skin.ToggleSetting(UseSingleShortcut)</onclick>
+                <selected>Skin.HasSetting(UseSingleShortcut)</selected>
+                <onclick>Skin.Reset(UseFixedHomeFocus)</onclick>
+                <onclick>Skin.Reset(EnhancedHome_Circular)</onclick>
+                <visible>Skin.String(HomeLayout, simplehor)</visible>
+            </control>
+			<!-- titan def vertical-->
+            <control type="radiobutton" id="13176001">
+                <include>SkinSettings_Button</include>
+                <label>"Titan $LOCALIZE[571] $LOCALIZE[31685]" $LOCALIZE[21480]</label>
+                <onclick>Skin.ToggleSetting(UseDefaultVerticalLayout)</onclick>
+				<visible>String.Contains(Skin.String(HomeLayout), ver)</visible>
+                <selected>Skin.HasSetting(UseDefaultVerticalLayout)</selected>
+            </control>
+            <!--left align simple home vertical-->
+            <control type="radiobutton" id="131760">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31760]</label>
+                <onclick>Skin.ToggleSetting(SimpleVerHomeLeftAlign)</onclick>
+                <visible>String.Contains(Skin.String(HomeLayout), simplever)</visible>
+                <selected>Skin.HasSetting(SimpleVerHomeLeftAlign)</selected>
+            </control>
+            <!--disable top row on netflix home-->
+            <control type="radiobutton" id="23604">
+                <include>SkinSettings_Button</include>
+                <label>Disable Spotlight Area</label>
+                <onclick>Skin.ToggleSetting(NetflixHomeDisableFirstRow)</onclick>
+				<onclick condition="Skin.HasSetting(SpotLightTrailers)">Skin.ToggleSetting(SpotLightTrailers)</onclick>
+                <onclick condition="Skin.HasSetting(NetflixAutoTrailer)">Skin.ToggleSetting(NetflixAutoTrailer)</onclick>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix)</visible>
+                <selected>Skin.HasSetting(NetflixHomeDisableFirstRow)</selected>
+            </control>
+			<!--show rating on home netflix home 1 and 2 -->
+            <control type="radiobutton" id="399764">
+                <include>SkinSettings_Button</include>
+                <label>Show Ratings</label>
+                <onclick>Skin.ToggleSetting(showratingnetflixhome)</onclick>
+                <selected>Skin.HasSetting(showratingnetflixhome)</selected>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix) + !Skin.HasSetting(NetflixHomeDisableFirstRow)</visible>
+            </control>
+			<!-- show media flags on netflix home -->
+            <control type="radiobutton" id="131766">
+                <include>SkinSettings_Button</include>
+                <label>Show Media Flags</label>
+                <onclick>Skin.ToggleSetting(HomemenuMediaFlags)</onclick>
+                <visible>Skin.String(HomeLayout,netflix2) + !Skin.HasSetting(NetflixHomeDisableFirstRow)</visible>
+                <selected>Skin.HasSetting(HomemenuMediaFlags)</selected>
+            </control>
+			<!--show studio logo on netflix home, , need re check-->
+            <control type="radiobutton" id="131767">
+                <include>SkinSettings_Button</include>
+                <label>Show Studio Logo</label>
+                <onclick>Skin.ToggleSetting(NetflixHomeStudio)</onclick>
+                <visible>Skin.String(HomeLayout,netflix2) + !Skin.HasSetting(NetflixHomeDisableFirstRow)</visible>
+                <selected>Skin.HasSetting(NetflixHomeStudio)</selected>
+            </control>
+            <!--Enable white rating flags in home , need re check-->
+            <control type="radiobutton" id="399766">
+                <include>SkinSettings_Button</include>
+                <label>Enable monochrome rating flags in home</label>
+                <onclick>Skin.ToggleSetting(EnableWhiteRatingInHome)</onclick>
+                <visible>Skin.String(HomeLayout,netflix2) + !Skin.HasSetting(NetflixHomeDisableFirstRow) + !Skin.HasSetting(NetflixHomeDisableRating)</visible>
+                <selected>Skin.HasSetting(EnableWhiteRatingInHome)</selected>
+            </control>
+			<!--home alternate borders-->
+            <control type="radiobutton" id="31638">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31638]</label>
+                <onclick>Skin.ToggleSetting(Home_TransParentTiles)</onclick>
+                <selected>Skin.HasSetting(Home_TransParentTiles)</selected>
+                <visible>Skin.String(HomeLayout,1) | Skin.String(HomeLayout,1small) | Skin.String(HomeLayout,2) | Skin.String(HomeLayout,2small) | Skin.String(HomeLayout,enhanced)</visible>
+            </control>
+			
+            <!-- default focus position-->
+            <control type="button" id="31727">
+                <include>SkinSettings_Button</include>
+                <label>31727</label>
+                <label2>$INFO[Skin.String(home.defaultfocus.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=home.defaultfocus,header=$LOCALIZE[31727])</onclick>
+                <visible>[!String.Contains(Skin.String(HomeLayout), netflix) + !Skin.String(HomeLayout, win10)] | Skin.HasSetting(AutoFocusHome)</visible>
+            </control>
+            <!-- submenu layout-->
+            <control type="button" id="23060">
+                <include>SkinSettings_Button</include>
+                <label>31312</label>
+                <label2>$INFO[Skin.String(SubmenuLayout.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=SubmenuLayout,header=$LOCALIZE[31312])</onclick>
+				<onclick condition="Skin.HasSetting(AutoShowSubmenu)">Skin.ToggleSetting(AutoShowSubmenu)</onclick>
+				<onclick condition="Skin.HasSetting(LowerWidgets)">Skin.ToggleSetting(LowerWidgets)</onclick>
+                <visible>[Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 2) | Skin.String(HomeLayout, 3) | Skin.String(HomeLayout, 1small) | Skin.String(HomeLayout, 2small) | Skin.String(HomeLayout, 3small)]</visible>
+            </control>
+             <!--toggle rss feed-->
+            <control type="radiobutton" id="23720">
+                <include>SkinSettings_Button</include>
+                <label>13305</label>
+                <onclick>RunScript(script.skin.helper.service,action=togglekodisetting,setting=lookandfeel.enablerssfeeds)</onclick>
+                <selected>system.getbool(lookandfeel.enablerssfeeds)</selected>
+                <visible>![Skin.String(HomeLayout, win10) | String.Contains(Skin.String(HomeLayout), netflix)]</visible>
+            </control>
+			<!-- HOMESCREEN Main Menu OPTIONS ,check-->
+            <control type="label" id="23011">
+                <include>SkinSettings_Header</include>
+                <label>Main and Sub Layout</label>
+            </control>
+			<!-- open submenu on click-->
+            <control type="radiobutton" id="23012">
+                <include>SkinSettings_Button</include>
+                <label>31561</label>
+                <onclick>Skin.ToggleSetting(OpenSubMenuOnClick)</onclick>
+                <selected>Skin.HasSetting(OpenSubMenuOnClick)</selected>
+                <visible>!String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+			<!-- auto show widgets-->
+            <control type="radiobutton" id="23013">
+                <include>SkinSettings_Button</include>
+                <label>31111</label>
+                <onclick>Skin.ToggleSetting(AutoShowWidgets)</onclick>
+				<onclick condition="Skin.HasSetting(AutoShowSubmenu) + Skin.String(HomeLayout, 2small) + Skin.String(SubmenuLayout, tiles)">Skin.ToggleSetting(AutoShowSubmenu)</onclick>
+                <selected>Skin.HasSetting(AutoShowWidgets)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+                <visible>[Skin.String(HomeLayout, 1small) | Skin.String(HomeLayout, 2small) | Skin.String(HomeLayout, 1)| Skin.String(HomeLayout, simplehor) | String.Contains(Skin.String(HomeLayout), lowhorizontal)]</visible> <!--  | Skin.String(HomeLayout, 2) entfernt -->
+            </control>
+            <!-- lower widgets-->
+            <control type="radiobutton" id="31660">
+                <include>SkinSettings_Button</include>
+                <label>31660</label>
+                <onclick>Skin.ToggleSetting(LowerWidgets)</onclick>
+                <selected>Skin.HasSetting(LowerWidgets)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+				<visible>!Skin.String(SubmenuLayout, tiles)</visible>
+                <visible>[Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 1small)] + Skin.HasSetting(AutoShowWidgets) + Skin.String(SubmenuLayout, horizontal)</visible>
+            </control>
+			<!--auto show home menu on netflix home or win10-->
+            <control type="radiobutton" id="31725">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31725]</label>
+                <onclick>Skin.ToggleSetting(AutoFocusHome)</onclick>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix) | Skin.String(HomeLayout,win10)</visible>
+                <selected>Skin.HasSetting(AutoFocusHome)</selected>
+            </control>
+			<!--enable auto show submenus-->
+            <control type="radiobutton" id="23014">
+                <include>SkinSettings_Button</include>
+                <label>31113</label>
+                <onclick>Skin.ToggleSetting(AutoShowSubmenu)</onclick>
+				<onclick condition="Skin.HasSetting(AutoShowWidgets) + Skin.String(HomeLayout, 2small) + Skin.String(SubmenuLayout, tiles)">Skin.ToggleSetting(AutoShowWidgets)</onclick>
+                <selected>Skin.HasSetting(AutoShowSubmenu)</selected>
+				<visible>!Skin.String(HomeLayout, enhanced)</visible>
+				<visible>!Skin.String(SubmenuLayout, vertical)</visible>
+				<visible>!Skin.String(SubmenuLayout, subpage)</visible>
+				<visible>[Skin.String(HomeLayout, 1small) | Skin.String(HomeLayout, 2small) | Skin.String(HomeLayout, 3small)| Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 2)]</visible>
+            </control>
+            <!--open submenu inline in vertical home-->
+            <control type="radiobutton" id="23515">
+                <include>SkinSettings_Button</include>
+                <label>31522</label>
+                <onclick>Skin.ToggleSetting(VerticalHomeInlineSubmenu)</onclick>
+                <selected>Skin.HasSetting(VerticalHomeInlineSubmenu)</selected>
+                <visible>[Skin.String(HomeLayout, simplever) | Skin.String(HomeLayout, simplever_tiles)]</visible>
+                <visible>!Skin.HasSetting(DisableAllSubmenus)</visible>
+            </control>
+            <!--disable all submenus-->
+            <control type="radiobutton" id="23017">
+                <include>SkinSettings_Button</include>
+                <label>31265</label>
+                <onclick>Skin.ToggleSetting(DisableAllSubmenus)</onclick>
+                <selected>Skin.HasSetting(DisableAllSubmenus)</selected>
+                <visible>!Skin.String(HomeLayout, enhanced) + !String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+            <!--enable cicular navigation-->
+            <control type="radiobutton" id="31619">
+                <include>SkinSettings_Button</include>
+                <label>31619</label>
+                <onclick>Skin.ToggleSetting(EnhancedHome_Circular)</onclick>
+                <selected>Skin.HasSetting(EnhancedHome_Circular)</selected>
+                <visible>![Skin.HasSetting(UseSingleShortcut) + Skin.String(HomeLayout, simplehor)]</visible>
+                <visible>Skin.String(HomeLayout, enhanced) | Skin.String(HomeLayout, netflix2) | Skin.String(HomeLayout, win10) | Skin.String(HomeLayout, simplehor) | String.Contains(Skin.String(HomeLayout), lowhorizontal)</visible>
+            </control>
+            <!--enable home menu animation-->
+            <control type="radiobutton" id="31620">
+                <include>SkinSettings_Button</include>
+                <label>31620</label>
+                <onclick>Skin.ToggleSetting(Vertical_Home_Animation)</onclick>
+                <selected>Skin.HasSetting(Vertical_Home_Animation)</selected>
+                <visible>[Skin.String(HomeLayout, simplever) | Skin.String(HomeLayout, simplever_tiles)]</visible>
+            </control>
+            
+			<!--Disable Profile Logo on MainMenu, re check-->
+            <control type="radiobutton" id="31749">
+                <include>SkinSettings_Button</include>
+                <label>Dont Show profile Logo</label>
+                <onclick>Skin.ToggleSetting(DisableProfileMainMenu)</onclick>
+                <selected>Skin.HasSetting(DisableProfileMainMenu)</selected>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+			<!--Disable Profile Logo on MainMenu, re check-->
+            <control type="radiobutton" id="31748">
+                <include>SkinSettings_Button</include>
+                <label>Dont Show Skin Logo in Home Menu Panel</label>
+                <onclick>Skin.ToggleSetting(DisableSkinIconMainMenu)</onclick>
+                <selected>Skin.HasSetting(DisableSkinIconMainMenu)</selected>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+
+            <!--Disable Icons in Main Menu Items, re check-->
+            <control type="radiobutton" id="31750">
+                <include>SkinSettings_Button</include>
+                <label>Disable Icons in Main Menu Items</label>
+                <onclick>Skin.ToggleSetting(DisableIconsMainMenu)</onclick>
+                <selected>Skin.HasSetting(DisableIconsMainMenu)</selected>
+                <visible>String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)</visible>
+            </control>
+            <!--hide power warning-->
+            <control type="label" id="23024">
+                <include>SkinSettings_Button</include>
+                <label>    $LOCALIZE[31199]</label>
+                <height>40</height>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+                <visible>Skin.HasSetting(DisablePowerMenu)</visible>
+            </control>
+            <!--disable power button-->
+            <control type="radiobutton" id="23025">
+                <include>SkinSettings_Button</include>
+                <label>31198</label>
+                <onclick>Skin.ToggleSetting(DisablePowerMenu)</onclick>
+                <selected>Skin.HasSetting(DisablePowerMenu)</selected>
+			</control>
+            <!--hide power button-->
+            <control type="radiobutton" id="23027">
+                <include>SkinSettings_Button</include>
+                <label>31594</label>
+                <onclick>Skin.ToggleSetting(HidePowerMenu)</onclick>
+                <selected>Skin.HasSetting(HidePowerMenu)</selected>
+                <visible>!Skin.HasSetting(DisablePowerMenu)</visible>
+			</control>
+			<!--no titles on home tiles-->
+            <control type="radiobutton" id="13014">
+                <include>SkinSettings_Button</include>
+                <label>31086</label>
+                <visible>[Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 2) | Skin.String(HomeLayout, 3) | Skin.String(HomeLayout, 1small) | Skin.String(HomeLayout, 2small) | Skin.String(HomeLayout, 3small) | Skin.String(HomeLayout, enhanced)]</visible>
+                <onclick>Skin.ToggleSetting(NoTitleOnHomeMenuTiles)</onclick>
+                <selected>Skin.HasSetting(NoTitleOnHomeMenuTiles)</selected>
+            </control>
+            <!--hide main menu panel-->
+			<control type="radiobutton" id="13006">
+                <include>SkinSettings_Button</include>
+                <label>Hide Main Menu Panel Background</label>
+                <onclick>Skin.ToggleSetting(HideMainPanelBackground)</onclick>
+                <selected>Skin.HasSetting(HideMainPanelBackground)</selected>
+                <visible>String.Contains(Skin.String(HomeLayout), ver)</visible>
+            </control>
+			<control type="label" id="23005">
+                <include>SkinSettings_Header</include>
+                <label>Home Screen Widgets</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<!--disable all widgets-->
+            <control type="radiobutton" id="23016">
+                <include>SkinSettings_Button</include>
+                <label>31264</label>
+                <onclick>Skin.ToggleSetting(DisableAllWidgets)</onclick>
+                <selected>Skin.HasSetting(DisableAllWidgets)</selected>
+                <visible>!Skin.String(HomeLayout, enhanced) + !Skin.String(HomeLayout, 3) + !String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+			<!-- use overlay HomeWidget  -->
+            <control type="radiobutton" id="13099">
+                <include>SkinSettings_Button</include>
+                <label>Use Dimmed Focus Overlay with play Button on Widgets</label>
+                <onclick>Skin.ToggleSetting(HomeWidget_FocusOverlay)</onclick>
+				<selected>Skin.HasSetting(HomeWidget_FocusOverlay)</selected>
+				<!-- <visible>!String.Contains(Skin.String(HomeLayout), netflix)</visible> -->
+            </control>
+			<!--enable widgets zoom effect-->
+            <control type="radiobutton" id="31763">
+                <include>SkinSettings_Button</include>
+                <label>31763</label>
+                <onclick>Skin.ToggleSetting(WidgetsZoomFocus)</onclick>
+                <selected>Skin.HasSetting(WidgetsZoomFocus)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.String(HomeLayout, 3) + !Skin.String(HomeLayout, enhanced)</visible>
+            </control>
+			<!--hide widget panel-->
+            <control type="radiobutton" id="13004">
+                <include>SkinSettings_Button</include>
+                <label>31206</label>
+                <onclick>Skin.ToggleSetting(HideWidgetPanelBackground)</onclick>
+                <selected>Skin.HasSetting(HideWidgetPanelBackground)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.String(HomeLayout, 3) + !Skin.String(HomeLayout, 3small) + !Skin.String(HomeLayout, win10) + !Skin.String(HomeLayout, netflix2)</visible>
+            </control>
+            <!--hide widget details-->
+            <control type="radiobutton" id="31707"> <!-- !Skin.String(HomeLayout, 1) + !Skin.String(HomeLayout, 2) + !Skin.String(HomeLayout, 1small) + !Skin.String(HomeLayout, 2small) wieder entfernen wenn lösung gefunden -->  
+                <include>SkinSettings_Button</include>
+                <label>31707</label>
+                <onclick>Skin.ToggleSetting(HideWidgetDetailsPanel)</onclick>
+                <selected>Skin.HasSetting(HideWidgetDetailsPanel)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.String(HomeLayout, 3) + !Skin.String(HomeLayout, 3small) + !Skin.String(HomeLayout, win10) + !String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+            <!--hide indicators on home tiles-->
+            <control type="radiobutton" id="31529">
+                <include>SkinSettings_Button</include>
+                <label>31529</label>
+                <onclick>Skin.ToggleSetting(HideHomeTileIndicators)</onclick>
+                <selected>Skin.HasSetting(HideHomeTileIndicators)</selected>
+                <visible>[Skin.String(HomeLayout, 1) | Skin.String(HomeLayout, 2) | Skin.String(HomeLayout, 1small) | [Skin.String(HomeLayout, 2small) + ![Skin.HasSetting(AutoShowWidgets) | Skin.HasSetting(AutoShowSubmenu)]] | Skin.String(HomeLayout, simplever)]</visible> <!-- [Skin.String(HomeLayout, 2small) + ![Skin.HasSetting(AutoShowWidgets) | Skin.HasSetting(AutoShowSubmenu)]] -->
+                <visible>![Skin.HasSetting(DisableAllWidgets) + Skin.HasSetting(DisableAllSubmenus)]</visible>
+            </control>
+					<!-- use submenui as widget layout -->
+					<!-- <control type="button" id="23721"> -->
+						<!-- <include>SkinSettings_Button</include> -->
+						<!-- <label>Layout for Submenu Widget</label> -->
+						<!-- - PLACEHOLDER - square, Landscape, .. - -->
+					<!-- </control> -->
+			<!-- widget layout, should just be set in shortcut section, use hidden if needed-->
+            <control type="button" id="23719">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31507] - will also be default in HUBS</label>
+                <label2>$INFO[Skin.String(widgetstyle.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=widgetstyle,header=$LOCALIZE[31507])</onclick>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.String(HomeLayout, 3) + !Skin.String(HomeLayout, 3small) + !Skin.String(HomeLayout, enhanced) + !Skin.String(HomeLayout, win10)</visible>
+            </control>
+			<control type="radiobutton" id="32789">
+                <include>SkinSettings_Button</include>
+                <label>Use Alternate Spotlight Button Layout</label>
+                <onclick>Skin.ToggleSetting(SpotlightButton_UseNF_Frame)</onclick>
+                <selected>Skin.HasSetting(SpotlightButton_UseNF_Frame)</selected>
+				<visible>String.Contains(Skin.String(HomeLayout), netflix)</visible>
+            </control>
+            <!--large widget area-->
+            <control type="radiobutton" id="31761">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31761]</label>
+                <onclick>Skin.ToggleSetting(VerticalHomeLargeWidget)</onclick>
+                <visible>String.Contains(Skin.String(HomeLayout), ver)</visible>
+                <selected>Skin.HasSetting(VerticalHomeLargeWidget)</selected>
+            </control>
+			<!-- enable auto-trailers in netflix home -->
+            <control type="radiobutton" id="28637">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[20410] $LOCALIZE[37026] $LOCALIZE[208]</label>
+                <onclick>Skin.ToggleSetting(NetflixAutoTrailer)</onclick>
+                <visible>!Skin.HasSetting(NetflixHomeDisableFirstRow) + String.Contains(Skin.String(HomeLayout), netflix)</visible>
+                <selected>Skin.HasSetting(NetflixAutoTrailer)</selected>
+            </control>
+            <!--Auto Trailer Interval-->
+            <control type="button" id="43699">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[20410] $LOCALIZE[37026] $LOCALIZE[208] Interval</label>
+                <label2>$INFO[Skin.String(auto_trailer_interval.label)]</label2>
+                <visible>!Skin.HasSetting(NetflixHomeDisableFirstRow) + String.Contains(Skin.String(HomeLayout), netflix) + Skin.HasSetting(NetflixAutoTrailer)</visible>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=auto_trailer_interval,header=Auto Trailer Interval)</onclick>
+            </control>
+			<!--spotlight widget trailer-->
+            <control type="radiobutton" id="31798">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[20410] $LOCALIZE[37026] $LOCALIZE[208] (Spotlight Widget)</label>
+                <onclick>Skin.ToggleSetting(SpotLightTrailers)</onclick>
+                <selected>Skin.HasSetting(SpotLightTrailers)</selected>
+                <visible>[!Skin.HasSetting(NetflixHomeDisableFirstRow) + String.Contains(Skin.String(HomeLayout), netflix)] | Skin.String(HomeLayout, enhanced)</visible>
+            </control>
+            <!--hide media flags & rating while trailer, check ID !!  -->
+            <control type="radiobutton" id="131786">
+                <include>SkinSettings_Button</include>
+                <label>Hide media flags and rating when playing trailer</label>
+                <onclick>Skin.ToggleSetting(HideMediaFlagsTrailer)</onclick>
+                <visible>!Skin.HasSetting(NetflixHomeDisableFirstRow) + Skin.String(HomeLayout,netflix2) + [Skin.HasSetting(SpotLightTrailers) | Skin.HasSetting(NetflixAutoTrailer)]</visible>
+                <selected>Skin.HasSetting(HideMediaFlagsTrailer)</selected>
+            </control>
+			
+            <!--large widget details-->
+            <control type="radiobutton" id="31741">
+                <include>SkinSettings_Button</include>
+                <label>31741</label>
+                <onclick>Skin.ToggleSetting(LargeWidgetDetailsPanel)</onclick>
+                <selected>Skin.HasSetting(LargeWidgetDetailsPanel)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.HasSetting(HideWidgetDetailsPanel) + String.Contains(Skin.String(HomeLayout), ver)</visible>
+            </control>
+			 <!--prefer tv show art for episodes-->
+            <control type="radiobutton" id="31304">
+                <include>SkinSettings_Button</include>
+                <label>31304</label>
+                <onclick>Skin.ToggleSetting(PreferTvShowThumbWidget)</onclick>
+                <selected>Skin.HasSetting(PreferTvShowThumbWidget)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + !Skin.String(HomeLayout, 3) + !Skin.String(HomeLayout, 3small)</visible>
+            </control>
+            <!--show all widgets at once, check will cause spotlight widget issues -->
+            <control type="radiobutton" id="31820">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31820]</label>
+                <onclick>Skin.ToggleSetting(ShowAllWidgets)</onclick>
+                <visible>String.Contains(Skin.String(HomeLayout), ver) | String.Contains(Skin.String(HomeLayout), netflix) | String.Contains(Skin.String(HomeLayout), win10)</visible>
+                <selected>Skin.HasSetting(ShowAllWidgets)</selected>
+            </control>
+			<!-- auto right align widgets -->
+            <control type="radiobutton" id="31712">
+                <include>SkinSettings_Button</include>
+                <label>31712</label>
+                <onclick>Skin.ToggleSetting(WidgetAlignRight)</onclick>
+				<onclick condition="Skin.HasSetting(WidgetCentered)">Skin.ToggleSetting(WidgetCentered)</onclick>
+                <selected>Skin.HasSetting(WidgetAlignRight)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+            </control>
+			<!-- auto centered align widgets -->
+            <control type="radiobutton" id="31713">
+                <include>SkinSettings_Button</include>
+                <label>auto centered align widgets</label>
+                <onclick>Skin.ToggleSetting(WidgetCentered)</onclick>
+				<onclick condition="Skin.HasSetting(WidgetAlignRight)">Skin.ToggleSetting(WidgetAlignRight)</onclick>
+                <selected>Skin.HasSetting(WidgetCentered)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+            </control>
+            <!-- widget rotate-->
+            <control type="button" id="31672">
+                <include>SkinSettings_Button</include>
+                <label>31672</label>
+                <label2>$INFO[Skin.String(widgets_rotate.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=widgets_rotate,header=$LOCALIZE[31672])</onclick>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+            </control>
+            <!-- widget rotate delay-->
+            <control type="button" id="31679">
+                <include>SkinSettings_Button</include>
+                <label>31679</label>
+                <label2>$INFO[Skin.String(widgets_rotate_delay.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=widgets_rotate_delay,header=$LOCALIZE[31679])</onclick>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + Skin.String(widgets_rotate) + !Skin.String(widgets_rotate,disabled)</visible>
+            </control>
+            <!-- widget rotate pause-->
+            <control type="radiobutton" id="31821">
+                <include>SkinSettings_Button</include>
+                <label>31821</label>
+                <onclick>Skin.ToggleSetting(widgets_rotate_pause)</onclick>
+                <selected>Skin.HasSetting(widgets_rotate_pause)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets) + Skin.String(widgets_rotate) + !Skin.String(widgets_rotate,disabled) + !String.Contains(Skin.String(HomeLayout),netflix)</visible>
+            </control>
+			<!-- en-disable tags on widgets removed, let shortcut decide -->
+			<!--   free id="31675" -->
+               
+			<!-- prefer plot outline -->
+            <control type="radiobutton" id="31794">
+                <include>SkinSettings_Button</include>
+                <label>31794</label>
+                <onclick>Skin.ToggleSetting(WidgetsPreferPlotOutline)</onclick>
+                <selected>Skin.HasSetting(WidgetsPreferPlotOutline)</selected>
+                <visible>!Skin.HasSetting(DisableAllWidgets)</visible>
+            </control>
+			<!-- Enable experimental spotlight content -->
+            <control type="radiobutton" id="28327">
+                <include>SkinSettings_Button</include>
+                <label>Enable experimental spotlight content</label>
+                <onclick>Skin.ToggleSetting(ExperimentalSpotlight)</onclick>
+                <visible>!Skin.HasSetting(NetflixHomeDisableFirstRow) + [Skin.String(HomeLayout,netflix2) | Skin.String(HomeLayout,netflix)]</visible>
+                <selected>Skin.HasSetting(ExperimentalSpotlight)</selected>
+            </control>
+            <!-- Allow tvshows in experimental content -->
+            <control type="radiobutton" id="28328">
+                <include>SkinSettings_Button</include>
+                <label>Allow TVShows in experimental spotlight content</label>
+                <onclick>Skin.ToggleSetting(AllowTVShowsSpotlight)</onclick>
+                <visible>!Skin.HasSetting(NetflixHomeDisableFirstRow) + Skin.String(HomeLayout,netflix2)</visible>
+                <selected>Skin.HasSetting(AllowTVShowsSpotlight)</selected>
+            </control>
+			
+            <!-- colorize custom home tiles -->
+            <control type="radiobutton" id="31755">
+                <include>SkinSettings_Button</include>
+                <label>31755</label>
+                <onclick>Skin.ToggleSetting(ColorizeHomeVerticalTiles)</onclick>
+                <selected>Skin.HasSetting(ColorizeHomeVerticalTiles)</selected>
+                <visible>Skin.String(HomeLayout,simplever_tiles)</visible>
+            </control>
+            <!-- do not uppercase font in modern big home menu layout -->
+            <control type="radiobutton" id="31810">
+                <include>SkinSettings_Button</include>
+                <label>31810</label>
+                <onclick>Skin.ToggleSetting(homemenu_nouppercase)</onclick>
+                <selected>Skin.HasSetting(homemenu_nouppercase)</selected>
+                <visible>Skin.String(HomeLayout,verticalbig) | String.Contains(Skin.String(HomeLayout),hor)</visible>
+            </control>
+        </control>
+         <!--scrollbar for homescreen layout-->
+        <control type="scrollbar" id="311"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>23000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),12)</visible>
+        </control>
+				
+    </include>
+    
+    <include name="SkinSettings_SmartShortcuts">
+        <!-- smart shortcuts -->
+        <control type="grouplist" id="19000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>19000</onup>
+            <ondown>19000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>313</onright>
+            <orientation>vertical</orientation>
+            <pagecontrol>313</pagecontrol>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),19)</visible>
+
+            <!-- smart shortcuts -->
+            <control type="label" id="19001">
+                <include>SkinSettings_Header</include>
+                <label>31323</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+                </control>
+            <control type="textbox" id="19002">
+                <description></description>
+                <width>100%</width>
+                <align>justify</align>
+                <label>31322</label>
+                <height>auto</height>
+                <font>Reg26</font>
+            </control>
+            <control type="label" id="19003">
+                <width>100%</width>
+                <height>10</height>
+            </control>
+            <control type="radiobutton" id="19010">
+                <include>SkinSettings_Button</include>
+                <label>31320</label>
+                <onclick>Skin.ToggleSetting(SmartShortcuts.playlists)</onclick>
+                <selected>Skin.HasSetting(SmartShortcuts.playlists)</selected>
+                <onclick>Notification($LOCALIZE[24074],$LOCALIZE[31546])</onclick>
+            </control>
+            <control type="radiobutton" id="19011">
+                <include>SkinSettings_Button</include>
+                <label>31321</label>
+                <onclick>Notification($LOCALIZE[24074],$LOCALIZE[31546])</onclick>
+                <onclick>Skin.ToggleSetting(SmartShortcuts.favorites)</onclick>
+                <selected>Skin.HasSetting(SmartShortcuts.favorites)</selected>
+            </control>
+            <control type="radiobutton" id="19012">
+                <include>SkinSettings_Button</include>
+                <label>31339</label>
+                <onclick>Skin.ToggleSetting(SmartShortcuts.emby)</onclick>
+                <selected>Skin.HasSetting(SmartShortcuts.emby) + System.HasAddon(plugin.video.emby)</selected>
+                <enable>System.HasAddon(plugin.video.emby)</enable>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Control.IsEnabled(19012)">Conditional</animation>
+            </control>
+            <control type="radiobutton" id="19013">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31532] (plexbmc)</label>
+                <onclick>Skin.ToggleSetting(SmartShortcuts.plex)</onclick>
+                <selected>Skin.HasSetting(SmartShortcuts.plex) + System.HasAddon(plugin.video.plexbmc)</selected>
+                <enable>System.HasAddon(plugin.video.plexbmc)</enable>
+                <onclick>Notification($LOCALIZE[24074],$LOCALIZE[31546])</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Control.IsEnabled(19013)">Conditional</animation>
+            </control>
+            <control type="label" id="19015">
+                <width>100%</width>
+                <height>10</height>
+            </control>
+            <control type="textbox" id="19016">
+                <description></description>
+                <width>1200</width>
+                <align>justify</align>
+                <label>31549</label>
+                <height>auto</height>
+                <font>Reg26</font>
+            </control>
+        </control>
+    </include>
+
+    <include name="SkinSettings_Background">
+        <!--background settings-->
+        <control type="grouplist" id="14000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>14000</onup>
+            <ondown>14000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>314</onright>
+            <pagecontrol>314</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),8)</visible>
+            <!-- skin background -->
+            <control type="label" id="14001">
+                <include>SkinSettings_Header</include>
+                <label>31142</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <!-- set global background -->
+            <control type="button" id="14002">
+                <include>SkinSettings_Button</include>
+                <label>31646</label>
+                <label2>$INFO[Skin.String(CustomBackgroundSetting.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=selectimage,skinstring=CustomBackgroundSetting,header=$LOCALIZE[31646],allowmulti=true,resourceaddon=resource.images.skinbackgrounds,skinhelperbackgrounds=true)</onclick>
+            </control>
+            <!-- enable section backgrounds -->
+            <control type="radiobutton" id="908">
+                <include>SkinSettings_Button</include>
+                <label>31647</label>
+                <onclick>Skin.ToggleSetting(UseSectionBackground)</onclick>
+                <selected>Skin.HasSetting(UseSectionBackground)</selected>
+            </control>
+            <!-- do not copy section backgrounds,check as default -->
+            <control type="radiobutton" id="31718">
+                <include>SkinSettings_Button</include>
+                <label>31718</label>
+                <onclick>Skin.ToggleSetting(SectionBackgroundHomeOnly)</onclick>
+                <onclick>ClearProperty(SectionBackground,Home)</onclick>
+                <selected>Skin.HasSetting(SectionBackgroundHomeOnly)</selected>
+            </control>
+            <!--custom overlay texture -->
+            <control type="button" id="14006">
+                <include>SkinSettings_Button</include>
+                <label>31470</label>
+                <label2>$INFO[Skin.String(BackgroundOverlayTexture.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=OVERLAYTEXTURE)</onclick>
+            </control>
+            <!-- overlay color diffuse -->
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="14008" />
+                <param name="label" value="$LOCALIZE[31151]" />
+                <param name="skinsetting" value="BackgroundOverlayColor" />
+            </include>
+            <!-- background color diffuse -->
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="14009" />
+                <param name="label" value="$LOCALIZE[31574]" />
+                <param name="skinsetting" value="BackgroundDiffuseColor" />
+            </include>
+            <!--overlay on media views only-->
+            <control type="radiobutton" id="14010">
+                <include>SkinSettings_Button</include>
+                <label>31234</label>
+                <onclick>Skin.ToggleSetting(BackgroundOverlayMediaViewOnly)</onclick>
+                <onclick condition="Skin.HasSetting(BackgroundOverlayHomeOnly)">Skin.Reset(BackgroundOverlayHomeOnly)</onclick>
+                <selected>Skin.HasSetting(BackgroundOverlayMediaViewOnly)</selected>
+                <visible>Skin.String(BackgroundOverlayTexture)</visible>
+            </control>
+            <!--overlay on home only-->
+            <control type="radiobutton" id="14011">
+                <include>SkinSettings_Button</include>
+                <label>31241</label>
+                <onclick>Skin.ToggleSetting(BackgroundOverlayHomeOnly)</onclick>
+                <onclick condition="Skin.HasSetting(BackgroundOverlayMediaViewOnly)">Skin.Reset(BackgroundOverlayMediaViewOnly)</onclick>
+                <selected>Skin.HasSetting(BackgroundOverlayHomeOnly)</selected>
+                <visible>Skin.String(BackgroundOverlayTexture)</visible>
+            </control>
+			<!--Color Monitor TMDB-helper -->
+			<control type="radiobutton" id="14012">
+                <include>SkinSettings_Button</include>
+                <label>Color Monitor (experimentally) TheMovieDb Helper Version 4 and higher</label>
+				<onclick condition="!System.HasAddon(plugin.video.themoviedb.helper)">InstallAddon(plugin.video.themoviedb.helper)</onclick>
+                <onclick>Skin.ToggleSetting(DisableColors)</onclick>
+                <onclick condition="!Skin.HasSetting(DisableColors)">Skin.SetBool(TMDbHelper.EnableColors)</onclick>
+				<onclick condition="Skin.HasSetting(DisableColors)">Skin.Reset(TMDbHelper.EnableColors)</onclick>
+                <selected>Skin.HasSetting(DisableColors)</selected>
+            </control>
+			<control type="radiobutton" id="14013">
+                <include>SkinSettings_Button</include>
+                <label>Color Monitor light colors</label>
+				<visible>Skin.HasSetting(DisableColors)</visible>
+                <onclick>Skin.ToggleSetting(LightColors)</onclick>
+                <onclick condition="!Skin.HasSetting(LightColors)">Skin.SetString(TMDbHelper.Colors.Luminance,0.13)</onclick>
+				<onclick condition="!Skin.HasSetting(LightColors)">Skin.SetString(TMDbHelper.Colors.Saturation,0.6)</onclick>
+				<onclick condition="Skin.HasSetting(LightColors)">Skin.SetString(TMDbHelper.Colors.Luminance,0.4)</onclick>
+				<onclick condition="Skin.HasSetting(LightColors)">Skin.SetString(TMDbHelper.Colors.Saturation,0.5)</onclick>
+                <selected>Skin.HasSetting(LightColors)</selected>
+            </control>
+            <!-- multi-image Background transition time-->
+            <control type="button" id="13019">
+                <include>SkinSettings_Button</include>
+                <label>31449</label>
+                <label2>$INFO[skin.string(SkinHelper.RandomFanartDelay.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=SkinHelper.RandomFanartDelay,header=$LOCALIZE[31449])</onclick>
+            </control>
+            <!--background animation-->
+            <control type="radiobutton" id="13018">
+                <include>SkinSettings_Button</include>
+                <label>31266</label>
+                <onclick>Skin.ToggleSetting(BackgroundAnimation)</onclick>
+                <selected>Skin.HasSetting(BackgroundAnimation)</selected>
+            </control>
+            <!--need check, enable wall backgrounds is alway set by default, resource hungry? 
+			https://github.com/kodi-community-addons/script.skin.helper.backgrounds
+			-->
+            <control type="radiobutton" id="31812">
+                <include>SkinSettings_Button</include>
+                <label>31812</label>
+                <onclick>Skin.ToggleSetting(SkinHelper.EnableWallBackgrounds)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.EnableWallBackgrounds)</selected>
+            </control>
+            <!-- skin helper backgrounds settings-->
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31531" />
+                <param name="addon" value="script.skin.helper.backgrounds" />
+            </include>
+            <!--background randomize, check, set always true ?-->
+            <control type="radiobutton" id="31747">
+                <include>SkinSettings_Button</include>
+                <label>31747</label>
+                <onclick>Skin.ToggleSetting(RandomizeBackground)</onclick>
+                <selected>Skin.HasSetting(RandomizeBackground)</selected>
+            </control>
+            <control type="label" id="13320">
+                <!--Seperator-->
+                <width>1200</width>
+                <height>15</height>
+            </control>
+            <!--section background-->
+            <control type="label" id="13321">
+                <include>SkinSettings_Header</include>
+                <label>$ADDON[script.skin.helper.backgrounds 32071]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+                </control>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="13325" />
+                <param name="label" value="$ADDON[script.skin.helper.backgrounds 32072]" />
+                <param name="action" value="RunScript(script.skin.helper.backgrounds,action=conditionalbackgrounds)" />
+                <param name="visible" value="true" />
+            </include>
+        </control>
+        <!--scrollbar for background settings-->
+        <control type="scrollbar" id="314"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>14000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),8)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_Library">
+        <!-- Media library views -->
+        <control type="grouplist" id="17000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>17000</onup>
+            <ondown>17000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>317</onright>
+            <pagecontrol>317</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),17)</visible>
+            
+			
+			<!-- Header Artwork Lib -->
+            <control type="label" id="170001">
+                <include>SkinSettings_Header</include>
+                <label>Artwork Settings</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			 <!--Show Fanart Background-->
+            <control type="radiobutton" id="320">
+                <include>SkinSettings_Button</include>
+                <label>31141</label>
+                <onclick>Skin.ToggleSetting(ShowFanartBackground)</onclick>
+                <selected>Skin.HasSetting(ShowFanartBackground)</selected>
+            </control>
+            <!-- Skinhelper - Show extra Fanart Background-->
+            <control type="radiobutton" id="338">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31207] - Use Skinhelper Service</label>
+                <onclick>Skin.ToggleSetting(SkinHelper.EnableExtraFanart)</onclick>
+				<onclick condition="Skin.HasSetting(EnableNativeExtraFanart)">Skin.ToggleSetting(EnableNativeExtraFanart)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.EnableExtraFanart)</selected>
+                <visible>Skin.HasSetting(ShowFanartBackground)</visible>
+                <visible>!Skin.HasSetting(LowPerformanceMode)</visible>
+            </control>
+			<!-- Native - Show extra Fanart Background 
+			, check corresponding toggles from skinhelper to implement -->
+            <control type="radiobutton" id="3381">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31207] - Dont Use Skinhelper Service</label>
+                <onclick>Skin.ToggleSetting(EnableNativeExtraFanart)</onclick>
+				<onclick condition="Skin.HasSetting(SkinHelper.EnableExtraFanart)">Skin.ToggleSetting(SkinHelper.EnableExtraFanart)</onclick>
+                <selected>Skin.HasSetting(EnableNativeExtraFanart)</selected>
+                <visible>Skin.HasSetting(ShowFanartBackground)</visible>
+            </control>
+             <!-- extra Fanart Background transition time-->
+            <control type="button" id="339">
+                <include>SkinSettings_Button</include>
+                <label>31296</label>
+                <label2>$INFO[skin.string(extrafanartdelay.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=extrafanartdelay,header=$LOCALIZE[31296])</onclick>
+                <visible>Skin.HasSetting(ShowFanartBackground) + [Skin.HasSetting(SkinHelper.EnableExtraFanart) + !Skin.HasSetting(EnableNativeExtraFanart)]</visible>
+            </control>
+            <!-- prefer fanart in landscaped views -->
+            <control type="radiobutton" id="13026">
+                <include>SkinSettings_Button</include>
+                <label>31210</label>
+                <onclick>Skin.ToggleSetting(DisableLandscapeThumbs)</onclick>
+                <selected>Skin.HasSetting(DisableLandscapeThumbs)</selected>
+            </control>
+			 <!-- alternative logo location -->
+            <control type="button" id="13027">
+                <include>SkinSettings_Button</include>
+                <label>31327</label>
+                <label2>$INFO[Skin.String(ClearLogoLocation.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=ClearLogoLocation,header=$LOCALIZE[31327])</onclick>
+            </control>
+			<!-- animated posters -->
+            <control type="radiobutton" id="31706">
+                <include>SkinSettings_Button</include>
+                <label>31706</label>
+                <onclick>Skin.ToggleSetting(EnableAnimatedPosters)</onclick>
+                <selected>Skin.HasSetting(EnableAnimatedPosters)</selected>
+            </control>
+            <control type="radiobutton" id="31802">
+                <include>SkinSettings_Button</include>
+                <label>31802</label>
+                <onclick>Skin.ToggleSetting(AnimatedPostersDisabledInLists)</onclick>
+                <selected>Skin.HasSetting(AnimatedPostersDisabledInLists)</selected>
+                <visible>Skin.HasSetting(EnableAnimatedPosters)</visible>
+            </control>
+            <control type="radiobutton" id="31803">
+                <include>SkinSettings_Button</include>
+                <label>31803</label>
+                <onclick>Skin.ToggleSetting(AnimatedFanart)</onclick>
+                <selected>Skin.HasSetting(AnimatedFanart)</selected>
+                <!-- <visible>Skin.HasSetting(EnableAnimatedPosters)</visible> -->
+            </control>
+			<control type="radiobutton" id="17118">
+                <include>SkinSettings_Button</include>
+                <label>31498</label>
+                <onclick>Skin.ToggleSetting(EnableFakeDiscArt)</onclick>
+                <selected>Skin.HasSetting(EnableFakeDiscArt)</selected>
+            </control>
+			<control type="radiobutton" id="17192">
+                <include>SkinSettings_Button</include>
+                <label>Use Netflix FontStyle in Netflix Views, NOTE: missing Cyrillic style</label>
+                <onclick>Skin.ToggleSetting(UseHelveticaNeueNetflix_font)</onclick>
+                <selected>Skin.HasSetting(UseHelveticaNeueNetflix_font)</selected>
+            </control>
+			
+			<!-- Header studio Lib -->
+            <control type="label" id="170003">
+                <include>SkinSettings_Header</include>
+                <label>Studio Logos</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<control type="radiobutton" id="17120">
+                <include>SkinSettings_Button</include>
+                <label>31509</label>
+                <onclick>Skin.ToggleSetting(StudioInFooter)</onclick>
+                <selected>Skin.HasSetting(StudioInFooter)</selected>
+            </control>
+			<control type="radiobutton" id="170010">
+                <include>SkinSettings_Button</include>
+                <label>Dont use Skinhelper for showing Studio Logos</label>
+                <onclick>Skin.ToggleSetting(NoSHStudioInFooter)</onclick>
+                <selected>Skin.HasSetting(NoSHStudioInFooter)</selected>
+            </control>
+			<!-- Header ratings Lib -->
+            <control type="label" id="170002">
+                <include>SkinSettings_Header</include>
+                <label>Ratings</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<!--Thumbs up rate value-->
+            <control type="button" id="172001">
+                <include>SkinSettings_Button</include>
+                <label>Thumbs Up rate value (User Rating Addon)</label>
+                <label2>$INFO[Skin.String(ThumbsUpRateValue.label)]</label2>
+                <visible>System.HasAddon(script.user.rating)</visible>
+				<!--<visible>Skin.String(HomeLayout,netflix2)</visible>-->
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=ThumbsUpRateValue,header=Thumbs Up rate value)</onclick>
+            </control>
+            <!--Thumbs down rate value-->
+            <control type="button" id="172002">
+                <include>SkinSettings_Button</include>
+                <label>Thumbs Down rate value (User Rating Addon)</label>
+                <label2>$INFO[Skin.String(ThumbsDownRateValue.label)]</label2>
+                <visible>System.HasAddon(script.user.rating)</visible>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=ThumbsDownRateValue,header=Thumbs Down rate value)</onclick>
+            </control>
+			<control type="radiobutton" id="31701">
+                <include>SkinSettings_Button</include>
+                <label>Show Thumbs instead of Stars Rating in Home Menu and Video Info</label>
+                <onclick>Skin.ToggleSetting(NetflixThumbRating)</onclick>
+                <selected>Skin.HasSetting(NetflixThumbRating)</selected>
+				<visible>Skin.String(HomeLayout,netflix2)</visible>
+			</control>
+			<!-- thumb down color-->
+			<include content="SkinSettings_ColorButton">
+				<param name="id" value="31836" />
+				<param name="label" value="Thumb Down color" />
+				<param name="skinsetting" value="ThumbDownColor" />
+				<param name="visible" value="Skin.HasSetting(NetflixThumbRating) + Skin.String(HomeLayout,netflix2)" />
+			</include>
+			<!-- thumb up color-->
+			<include content="SkinSettings_ColorButton">
+				<param name="id" value="31837" />
+				<param name="label" value="Thumb Up color" />
+				<param name="skinsetting" value="ThumbUpColor" />
+				<param name="visible" value="Skin.HasSetting(NetflixThumbRating) + Skin.String(HomeLayout,netflix2)" />
+			</include>
+            <!--Thumbs up min. value
+            <control type="button" id="17200">
+                <include>SkinSettings_Button</include>
+                <label>Minimum (inclusive) user rating to show thumbs up</label>
+                <label2>$INFO[Skin.String(ThumbsUpMin.label)]</label2>
+                <visible>Skin.String(HomeLayout,netflix2)</visible>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=ThumbsUpMin,header=Thumbs Up min. value)</onclick>
+            </control>
+			-->
+            <!--Thumbs down max. value
+            <control type="button" id="17201">
+                <include>SkinSettings_Button</include>
+                <label>Maximum (inclusive) user rating to show thumbs down</label>
+                <label2>$INFO[Skin.String(ThumbsDownMax.label)]</label2>
+                <visible>Skin.String(HomeLayout,netflix2)</visible>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=ThumbsDownMax,header=Thumbs Down max. value)</onclick>
+            </control>
+			-->
+            <!--Enable white rating flags -->
+            <control type="radiobutton" id="399765">
+                <include>SkinSettings_Button</include>
+                <label>Enable Monochrome Rating Logos in footer</label>
+                <onclick>Skin.ToggleSetting(EnableWhiteRatingInFooter)</onclick>
+				<selected>Skin.HasSetting(EnableWhiteRatingInFooter)</selected>
+            </control>
+			 <control type="radiobutton" id="17201">
+                <include>SkinSettings_Button</include>
+                <label>Use Skinhelper as Fallack for special ratings</label>
+                <onclick>Skin.ToggleSetting(SH_Rating_Fallback)</onclick>
+                <selected>Skin.HasSetting(SH_Rating_Fallback)</selected>
+            </control>
+            <control type="radiobutton" id="399767">
+                <include>SkinSettings_Button</include>
+                <label>31607</label>
+                <onclick>Skin.ToggleSetting(show_imdb_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_imdb_RatingInFooter)</selected>
+                
+            </control>
+			<control type="radiobutton" id="17123">
+                <include>SkinSettings_Button</include>
+                <label>TMdb Rating In Footer</label>
+                <onclick>Skin.ToggleSetting(show_themoviedb_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_themoviedb_RatingInFooter)</selected>
+                
+            </control>
+			<control type="radiobutton" id="17129">
+                <include>SkinSettings_Button</include>
+                <label>TVdb Rating In Footer</label>
+                <onclick>Skin.ToggleSetting(show_tvdb_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_tvdb_RatingInFooter)</selected>
+                
+            </control>
+			
+            <control type="radiobutton" id="31775">
+                <include>SkinSettings_Button</include>
+                <label>Rotten Tomato Critics</label>
+                <onclick>Skin.ToggleSetting(show_tomatometerallcritics_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_tomatometerallcritics_RatingInFooter)</selected>
+                
+            </control>
+			
+			<control type="radiobutton" id="17193">
+                <include>SkinSettings_Button</include>
+                <label>Rotten Tomato Audience</label>
+                <onclick>Skin.ToggleSetting(show_tomatometerallaudience_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_tomatometerallaudience_RatingInFooter)</selected>
+                
+            </control>
+			<control type="radiobutton" id="17194">
+                <include>SkinSettings_Button</include>
+                <label>Metacritic</label>
+                <onclick>Skin.ToggleSetting(show_metacritic_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_metacritic_RatingInFooter)</selected>
+                
+            </control>
+			<control type="radiobutton" id="17195">
+                <include>SkinSettings_Button</include>
+                <label>Imdb Top 250</label>
+                <onclick>Skin.ToggleSetting(show_imdbtop250_RatingInFooter)</onclick>
+                <selected>Skin.HasSetting(show_imdbtop250_RatingInFooter)</selected>
+                
+            </control>
+            
+			<!-- Header trailer Lib -->
+            <control type="label" id="170005">
+                <include>SkinSettings_Header</include>
+                <label>Media Flag Settings</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<!-- style for codec info -->
+            <control type="button" id="13029">
+                <include>SkinSettings_Button</include>
+                <label>31632</label>
+                <label2>$INFO[Skin.String(mediaflagsstyle.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=mediaflagsstyle,header=$LOCALIZE[31632])</onclick>
+                
+            </control>
+			<!-- style for codec frames netflix detail row -->
+            <control type="radiobutton" id="13033">
+                <include>SkinSettings_Button</include>
+                <label>Use Hard Edge A/V Codec Info Frames (just Netflix Views)</label>
+                <onclick>Skin.ToggleSetting(HardEdgeNetflixFrames)</onclick>
+                <selected>Skin.HasSetting(HardEdgeNetflixFrames)</selected>
+            </control>
+			<!-- alt mpaa image -->
+            <control type="radiobutton" id="13036">
+                <include>SkinSettings_Button</include>
+                <label>Dont use framed mpaa (Use Netflix MPAA)</label>
+                <onclick>Skin.ToggleSetting(NetflixMPAA)</onclick>
+				<onclick condition="Skin.HasSetting(CodecSameLabelColorAsFrames)">Skin.ToggleSetting(CodecSameLabelColorAsFrames)</onclick>
+                <selected>Skin.HasSetting(NetflixMPAA)</selected>
+            </control>
+			<!-- style for Codec Frames and Label in same color -->
+            <control type="radiobutton" id="13034">
+                <include>SkinSettings_Button</include>
+                <label>Use Codec Frames and Codec Label in same color (just Netflix Views)</label>
+                <onclick>Skin.ToggleSetting(CodecSameLabelColorAsFrames)</onclick>
+                <selected>Skin.HasSetting(CodecSameLabelColorAsFrames)</selected>
+            </control>
+			
+			<!-- Header trailer Lib -->
+            <control type="label" id="170004">
+                <include>SkinSettings_Header</include>
+                <label>Trailer Settings</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			
+			<!-- Local Trailer -->
+            <control type="radiobutton" id="55146">
+				<include>SkinSettings_Button</include>
+				<label>Local Trailer Search("Title"-trailer.mp4) disable</label>
+				<onclick>Skin.ToggleSetting(Library_NoOnlineLookupTrailer)</onclick>
+				<selected>Skin.HasSetting(Library_NoOnlineLookupTrailer)</selected>
+			</control>
+			<control type="radiobutton" id="55147">
+				<include>SkinSettings_Button</include>
+				<label>Auto search Youtube Trailer (Videoinfo) disable</label>
+				<onclick>Skin.ToggleSetting(YoutubeNoOnlineLookup)</onclick>
+				<selected>Skin.HasSetting(YoutubeNoOnlineLookup)</selected>
+			</control>
+			<!-- media library views -->
+            <control type="label" id="13020">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[31221]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+           
+			
+			<!-- use focus overlay lib -->
+            <control type="radiobutton" id="13031">
+                <include>SkinSettings_Button</include>
+                <label>Use Dimmed Overlay on Focused Item</label>
+                <onclick>Skin.ToggleSetting(LibItems_FocusOverlay)</onclick>
+				<selected>Skin.HasSetting(LibItems_FocusOverlay)</selected>
+            </control>
+			
+            <!-- show movie title -->
+            <control type="radiobutton" id="13028">
+                <include>SkinSettings_Button</include>
+                <label>31235</label>
+                <onclick>Skin.ToggleSetting(ShowMovieTitleHeader)</onclick>
+                <selected>Skin.HasSetting(ShowMovieTitleHeader)</selected>
+            </control>
+            
+			<control type="radiobutton" id="17122">
+                <include>SkinSettings_Button</include>
+                <label>31613</label>
+                <onclick>Skin.ToggleSetting(DisableSideBladeIndicator)</onclick>
+                <selected>Skin.HasSetting(DisableSideBladeIndicator)</selected>
+            </control>
+            <control type="radiobutton" id="31739">
+                <include>SkinSettings_Button</include>
+                <label>31738</label>
+                <onclick>Skin.ToggleSetting(DisableScrollingLetters)</onclick>
+                <selected>Skin.HasSetting(DisableScrollingLetters)</selected>
+            </control>
+            <control type="radiobutton" id="31746">
+                <include>SkinSettings_Button</include>
+                <label>31746</label>
+                <onclick>Skin.ToggleSetting(EnableQuickJump)</onclick>
+                <selected>Skin.HasSetting(EnableQuickJump)</selected>
+            </control>
+             <!-- video information dialog -->
+            <control type="label" id="12001">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[12001]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="2015902">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[14083] $LOCALIZE[12001]</label>
+                <onclick>Skin.ToggleSetting(UseFullscreenDialog)</onclick> 				
+                <selected>Skin.HasSetting(UseFullscreenDialog)</selected>
+            </control>
+            <!-- video information dialog -->
+            <control type="label" id="20159">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[12003]</label> <!-- uncorrect string in kodi main res-german ?-->
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="17233">
+                <include>SkinSettings_Button</include>
+                <label>Use $LOCALIZE[31018] $LOCALIZE[12003]</label>
+                <onclick>Skin.ToggleSetting(UseNetflixInfoDialog)</onclick>
+				<onclick condition="Skin.HasSetting(UseEnhancedDialog)">Skin.ToggleSetting(UseEnhancedDialog)</onclick> 				
+                <selected>Skin.HasSetting(UseNetflixInfoDialog)</selected>
+            </control>
+			<control type="radiobutton" id="17124">
+                <include>SkinSettings_Button</include>
+                <label>Use Enhanced (WIP) Info</label>
+                <onclick>Skin.ToggleSetting(UseEnhancedDialog)</onclick> 
+				<onclick condition="Skin.HasSetting(UseNetflixInfoDialog)">Skin.ToggleSetting(UseNetflixInfoDialog)</onclick> 
+                <selected>Skin.HasSetting(UseEnhancedDialog)</selected>
+            </control>
+			<control type="radiobutton" id="17119">
+                <include>SkinSettings_Button</include>
+                <label>31508</label>
+                <onclick condition="System.HasAddon(script.extendedinfo)">Skin.ToggleSetting(UseExtendedInfoDialog)</onclick>
+                <onclick condition="!System.HasAddon(script.extendedinfo)">RunPlugin(plugin://script.extendedinfo)</onclick>
+                <selected>Skin.HasSetting(UseExtendedInfoDialog)</selected>
+            </control>
+			<!-- Show next/resumable ep. info instead of tvshow's -->
+            <control type="radiobutton" id="39275">
+                <include>SkinSettings_Button</include>
+                <label>Show Current/Next Episode Plot in TVShow's InfoDialog</label>
+                <onclick>Skin.ToggleSetting(ShowEpisodePlotInfoDialog)</onclick>
+                <selected>Skin.HasSetting(ShowEpisodePlotInfoDialog)</selected>
+                <visible>!Skin.HasSetting(UseExtendedInfoDialog)</visible>
+				<visible>Skin.HasSetting(UseNetflixInfoDialog)</visible>
+            </control>
+			<!-- actor list behaviour in videoinfo -->
+            <control type="button" id="31689">
+                <include>SkinSettings_Button</include>
+                <label>31689</label>
+                <label2>$INFO[Skin.String(videoinfo_castaction.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=videoinfo_castaction,header=$LOCALIZE[31689])</onclick>
+                <visible>!Skin.HasSetting(UseExtendedInfoDialog)</visible>
+            </control>
+            <!-- trailer behaviour in videoinfo 
+			<control type="radiobutton" id="31694">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[20410] $LOCALIZE[37026] $LOCALIZE[208]</label>
+                <onclick>Skin.ToggleSetting(videoinfo_traileraction,auto)</onclick>
+                <selected>Skin.HasSetting(videoinfo_traileraction,auto)</selected>
+				<visible>!Skin.HasSetting(UseExtendedInfoDialog)</visible>
+            </control>
+			disabled in case of play in loop bug -->
+			<!-- Enable auto-hide details when trailer is playing -->
+            <control type="radiobutton" id="41634">
+                <include>SkinSettings_Button</include>
+                <label>Enable auto-hide details when trailer is playing</label>
+                <onclick>Skin.ToggleSetting(AutoHideDetailsOnTrailer)</onclick>
+                <selected>Skin.HasSetting(AutoHideDetailsOnTrailer)</selected>
+                <visible>Skin.HasSetting(UseNetflixInfoDialog)</visible>
+            </control>
+			<control type="radiobutton" id="31674">
+                <!-- hide filename in videoinfo -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31674</label>
+                <onclick>Skin.ToggleSetting(DialogVideoInfo_HideFileName)</onclick>
+                <selected>Skin.HasSetting(DialogVideoInfo_HideFileName)</selected>
+				<visible>Skin.HasSetting(UseExtendedInfoDialog) | !Skin.HasSetting(UseNetflixInfoDialog)</visible>
+            </control>
+            <!-- Select which buttons to show in videoinfo -->
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="31695" />
+                <param name="label" value="31695" />
+                <param name="action" value="RunScript(script.skin.helper.service,action=setskinsetting,setting=videoinfo_buttons,header=$LOCALIZE[31695])" />
+                <param name="visible" value="!Skin.HasSetting(UseExtendedInfoDialog)" />
+            </include>
+            
+            <!-- watched indicators -->
+            <control type="label" id="17130">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[31512]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="17131">
+                <include>SkinSettings_Button</include>
+                <label>31513</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.Watched)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.Watched)</selected>
+            </control>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17132" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Watched.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Watched)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17133" />
+                <param name="label" value="$LOCALIZE[31521]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Watched.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Watched)" />
+            </include>
+                 <control type="radiobutton" id="17134">
+                <include>SkinSettings_Button</include>
+                <label>31514</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.Progress)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.Progress)</selected>
+            </control>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17135" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Progress.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Progress)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17136" />
+                <param name="label" value="$LOCALIZE[31521]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Progress.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Progress)" />
+            </include>
+
+            <control type="radiobutton" id="17137">
+                <include>SkinSettings_Button</include>
+                <label>31515</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.Sets)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.Sets)</selected>
+            </control>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17138" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Sets.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Sets)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17139" />
+                <param name="label" value="$LOCALIZE[31521]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Sets.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Sets)" />
+            </include>
+            <control type="radiobutton" id="17140">
+                <include>SkinSettings_Button</include>
+                <label>31516</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.Episodes)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.Episodes)</selected>
+            </control>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17141" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Episodes.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Episodes)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17142" />
+                <param name="label" value="$LOCALIZE[31521]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Episodes.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Episodes)" />
+            </include>
+            <control type="radiobutton" id="17160">
+                <include>SkinSettings_Button</include>
+                <label>31568</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.UnWatched)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.UnWatched)</selected>
+            </control>
+           <include content="SkinSettings_ColorButton">
+                <param name="id" value="17161" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.UnWatched.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.UnWatched)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17162" />
+                <param name="label" value="$LOCALIZE[31521]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.UnWatched.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.UnWatched)" />
+            </include>
+            <control type="radiobutton" id="31789">
+                <include>SkinSettings_Button</include>
+                <label>31789</label>
+                <onclick>Skin.ToggleSetting(WatchedIndicator.Playing)</onclick>
+                <selected>Skin.HasSetting(WatchedIndicator.Playing)</selected>
+            </control>
+           <include content="SkinSettings_ColorButton">
+                <param name="id" value="317891" />
+                <param name="label" value="$LOCALIZE[31517]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Playing.Color" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Playing)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="31790" />
+                <param name="label" value="$LOCALIZE[31790]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="WatchedIndicator.Playing.TextColor" />
+                <param name="visible" value="Skin.HasSetting(WatchedIndicator.Playing)" />
+            </include>
+            
+            <!-- poster overlays -->
+            <control type="label" id="17150">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[31524]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="17151">
+                <include>SkinSettings_Button</include>
+                <label>31525</label>
+                <onclick>Skin.ToggleSetting(CaseOverlays)</onclick>
+                <selected>Skin.HasSetting(CaseOverlays)</selected>
+            </control>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17152" />
+                <param name="label" value="$LOCALIZE[31526]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="CaseOverlays.Color" />
+                <param name="visible" value="Skin.HasSetting(CaseOverlays)" />
+            </include>
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="17153" />
+                <param name="label" value="$LOCALIZE[31527]" />
+                <param name="labelprefix" value="  --- " />
+                <param name="skinsetting" value="CaseOverlays.TextColor" />
+                <param name="visible" value="Skin.HasSetting(CaseOverlays)" />
+            </include>
+
+            <include>SkinSettings_GamePlatformShapes</include>
+        </control>
+        <!--scrollbar for medialibrary settings-->
+        <control type="scrollbar" id="317"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>17000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),17)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_Library_Colors">
+         <!-- media library views -->
+        <control type="label" id="1999">
+            <include>SkinSettings_Header</include>
+            <label>$LOCALIZE[31221]</label>
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+        
+		<!-- Lib_PlayButtonColor -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31862" />
+            <param name="label" value="Color for Dim Overlay Play Button" />
+            <param name="skinsetting" value="Lib_PlayButtonColor" />
+        </include>
+		<!-- THUMB border color FOCUS -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31828" />
+            <param name="label" value="Media THUMB Border Color (Focus)" />
+            <param name="skinsetting" value="ViewDetailsBorderFocusColor" />
+        </include>
+		<!-- viewdetails UNFOCUSED THUMB BORDER / unfocused bg -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31472" />
+            <param name="label" value="Media THUMB Border Color (No Focus)" />
+            <param name="skinsetting" value="ViewDetailsPanelColor" />
+        </include>
+		<!-- LIST PANEL FOCUS -->
+		<include content="SkinSettings_ColorButton">
+            <param name="id" value="31571" />
+            <param name="label" value="Media LIST PANEL Color (Focus)" />
+            <param name="skinsetting" value="ViewDetailsFocusColor" />
+        </include>
+		<!-- LIST PANEL  UNFOCUSED  BG and  DETAIL PANELS -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31474" />
+            <param name="label" value="Media LIST PANEL (No Focus) + DETAIL PANELS BG" />
+            <param name="skinsetting" value="ViewListAndDetailPanelColorNF" />
+        </include>
+		<!--viewdetails BG color overlay of fanart , needed for 507 (523,525,526,527 use netflix colors) -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31575" />
+            <param name="label" value="Media Background Color if No Global Background Image is in use" />
+            <param name="skinsetting" value="ViewDetailsBGColor" />
+        </include>
+		<!--viewdetails text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31222" />
+            <param name="label" value="$LOCALIZE[31222]" />
+            <param name="skinsetting" value="ViewDetailsTextColor" />
+        </include>
+		<!--view details shadow color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31223" />
+            <param name="label" value="$LOCALIZE[31223]" />
+            <param name="skinsetting" value="ViewDetailsTextShadowColor" />
+        </include>
+         <!--viewdetails highlights color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31226" />
+            <param name="label" value="$LOCALIZE[31226]" />
+            <param name="skinsetting" value="ViewDetailsHighlightTextColor" />
+        </include>
+         <!--view details highlights shadow color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31227" />
+            <param name="label" value="$LOCALIZE[31227]" />
+            <param name="skinsetting" value="ViewDetailsHighlightTextShadowColor" />
+        </include>
+		<!--listitem text unfocus color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31569" />
+            <param name="label" value="$LOCALIZE[31569]" />
+            <param name="skinsetting" value="ViewDetailsListItemTextColor" />
+        </include>
+         <!--listitem text focus color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31570" />
+            <param name="label" value="$LOCALIZE[31570]" />
+            <param name="skinsetting" value="ViewDetailsListItemTextFocusColor" />
+        </include>
+        
+		<!-- Netflix VIEWS -->
+		<control type="label" id="19991">
+            <include>SkinSettings_Header</include>
+            <label>$LOCALIZE[31018] $LOCALIZE[31221]</label>
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+		<!-- netflix views/home bg color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31303" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[745]" />
+            <param name="skinsetting" value="NetflixBGColor" />
+        </include>
+		 <!--Netflix viewdetails panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31842" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[31472]" />
+            <param name="skinsetting" value="NetflixViewDetailsPanelColor" />
+        </include>
+		<!--Netflix viewdetails border focus color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31843" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[31828]" />
+            <param name="skinsetting" value="NetflixViewDetailsBorderFocusColor" />
+        </include>
+		<!--Netflix Primary Text Color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31830" />
+            <param name="label" value="$LOCALIZE[31830]" />
+            <param name="skinsetting" value="NetflixPrimaryTextColor" />
+        </include>
+        <!--Netflix Secondary Text Color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31831" />
+            <param name="label" value="$LOCALIZE[31831]" />
+            <param name="skinsetting" value="NetflixSecondaryTextColor" />
+        </include>
+		<!--Netflix Highlight Text Color - Ratings -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31840" />
+            <param name="label" value="$LOCALIZE[31018] Highlight Color" />
+            <param name="skinsetting" value="ViewNetfixHighlightTextColor" />
+        </include>
+		<include content="SkinSettings_ColorButton">
+            <param name="id" value="31822" />
+            <param name="label" value="$LOCALIZE[31018] Secondary Highlight Color" />
+            <param name="skinsetting" value="ViewNetfixSecondaryHighlightTextColor" />
+        </include>
+		<!-- Netflix Details Flag Color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31832" />
+            <param name="label" value="$LOCALIZE[31018] Detail (mpaa and codec) Frames Color" />
+            <param name="skinsetting" value="NetflixDetailsFlagColor" />
+        </include>
+		<!-- footer text color (if  netflix) -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31833" />
+            <param name="label" value="$LOCALIZE[31018] ($LOCALIZE[563] and Media Flags Color)" />
+            <param name="skinsetting" value="RatingsLogoColor" />
+        </include>
+    </include>
+    
+    <include name="SkinSettings_ForcedViews">
+        <!-- Forced views -->
+        <control type="grouplist" id="7000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>7000</onup>
+            <ondown>7000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>37</onright>
+            <pagecontrol>37</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),7)</visible>
+                 <!-- forced views -->
+            <control type="label" id="6027">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[31518]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <!-- enable/disable views -->
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="6026" />
+                <param name="label" value="31487" />
+                <param name="action" value="RunScript(script.skin.helper.service,action=ENABLEVIEWS,richlayout=true)" />
+                <param name="visible" value="true" />
+            </include>
+            <!-- white space -->
+            <control type="label" id="6025">
+                <height>50</height>
+            </control>
+
+            <control type="radiobutton" id="6009">
+                <include>SkinSettings_Button</include>
+                <onclick>Skin.ToggleSetting(SkinHelper.ForcedViews.Enabled)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.ForcedViews.Enabled)</selected>
+                <label>31488</label>
+            </control>
+
+            <control type="button" id="6010">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=movies)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31489</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.movies.label)]$INFO[Skin.String(SkinHelper.ForcedViews.movies), (,)]</label2>
+            </control>
+            <control type="button" id="6011">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=tvshows)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31490</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.tvshows.label)]$INFO[Skin.String(SkinHelper.ForcedViews.tvshows), (,)]</label2>
+            </control>
+            <control type="button" id="6012">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=seasons)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31491</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.seasons.label)]$INFO[Skin.String(SkinHelper.ForcedViews.seasons), (,)]</label2>
+            </control>
+            <control type="button" id="6013">
+               <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=episodes)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31492</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.episodes.label)]$INFO[Skin.String(SkinHelper.ForcedViews.episodes), (,)]</label2>
+            </control>
+            <control type="button" id="6014">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=sets)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31502</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.sets.label)]$INFO[Skin.String(SkinHelper.ForcedViews.sets), (,)]</label2>
+            </control>
+            <control type="button" id="6015">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=setmovies)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31503</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.setmovies.label)]$INFO[Skin.String(SkinHelper.ForcedViews.setmovies), (,)]</label2>
+            </control>
+            <control type="button" id="6016">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=tvchannels)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31581</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.tvchannels.label)]$INFO[Skin.String(SkinHelper.ForcedViews.tvchannels), (,)]</label2>
+            </control>
+            <control type="button" id="6017">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=tvrecordings)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31582</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.tvrecordings.label)]$INFO[Skin.String(SkinHelper.ForcedViews.tvrecordings), (,)]</label2>
+            </control>
+             <control type="button" id="6018">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=addons)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31583</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.addons.label)]$INFO[Skin.String(SkinHelper.ForcedViews.addons), (,)]</label2>
+            </control>
+            <control type="button" id="6019">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=files)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31584</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.files.label)]$INFO[Skin.String(SkinHelper.ForcedViews.files), (,)]</label2>
+            </control>
+            <control type="button" id="6020">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=artists)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31585</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.artists.label)]$INFO[Skin.String(SkinHelper.ForcedViews.artists), (,)]</label2>
+            </control>
+            <control type="button" id="6021">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=albums)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31586</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.albums.label)]$INFO[Skin.String(SkinHelper.ForcedViews.albums), (,)]</label2>
+            </control>
+            <control type="button" id="6022">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=songs)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31587</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.songs.label)]$INFO[Skin.String(SkinHelper.ForcedViews.songs), (,)]</label2>
+            </control>
+            <control type="button" id="6023">
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.service,action=SETFORCEDVIEW,contenttype=pictures)</onclick>
+                <animation effect="fade" start="100" end="40" time="0" condition="!Skin.HasSetting(SkinHelper.ForcedViews.Enabled)">Conditional</animation>
+                <label>31588</label>
+                <label2>$INFO[Skin.String(SkinHelper.ForcedViews.pictures.label)]$INFO[Skin.String(SkinHelper.ForcedViews.pictures), (,)]</label2>
+            </control>
+        </control>
+        <!--scrollbar for forced view settings-->
+        <control type="scrollbar" id="37"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>7000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),7)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_OSD">
+        <!-- OSD -->
+        <control type="grouplist" id="16000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>16000</onup>
+            <ondown>16000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>316</onright>
+            <pagecontrol>316</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),16)</visible>
+            
+            <!-- OSD generic -->
+            <control type="label" id="478">
+                <include>SkinSettings_Header</include>
+                <label>478</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            
+			<!-- toggle slim osd ON , need re check (selected /toggle)-->
+            <control type="radiobutton" id="13060">
+                <include>SkinSettings_Button</include>
+                <label>31476</label>
+                <onclick>Skin.ToggleSetting(UseSlimOSDPanel)</onclick>
+                <selected>Skin.HasSetting(UseSlimOSDPanel)</selected>
+				<onclick>Skin.ToggleSetting(UseModernOSDPanel)</onclick>
+                <selected>!Skin.HasSetting(UseModernOSDPanel)</selected>
+				<onclick condition="Skin.HasSetting(UseNetflixOSDPanel)">Skin.ToggleSetting(UseNetflixOSDPanel)</onclick>
+				<selected>!Skin.HasSetting(UseNetflixOSDPanel)</selected>
+                
+				<visible>!Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+
+			<!-- toggle "fake"  slim osd OFF -->
+			<control type="radiobutton" id="13061">
+                <include>SkinSettings_Button</include>
+                <label>Use Default OSD</label>               
+				<onclick>Skin.ToggleSetting(UseModernOSDPanel)</onclick>
+                <selected>Skin.HasSetting(UseModernOSDPanel)</selected>
+				<onclick>Skin.ToggleSetting(UseSlimOSDPanel)</onclick>
+                <selected>!Skin.HasSetting(UseSlimOSDPanel)</selected>
+   				<onclick condition="Skin.HasSetting(UseNetflixOSDPanel)">Skin.ToggleSetting(UseNetflixOSDPanel)</onclick>
+				<selected>!Skin.HasSetting(UseNetflixOSDPanel)</selected>
+				
+				<visible>!Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+			
+			<!-- toggle netflix OSD -->
+			<control type="radiobutton" id="14273">
+                <include>SkinSettings_Button</include>
+                <label>Use Netflix OSD Panel</label>
+				<onclick>Skin.ToggleSetting(UseNetflixOSDPanel)</onclick>
+				<selected>Skin.HasSetting(UseNetflixOSDPanel)</selected>
+				
+            </control>
+			
+            <control type="button" id="31698">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31698]</label>
+                <label2>$INFO[Skin.String(osd_buttonstyle.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=osd_buttonstyle,header=$LOCALIZE[31698])</onclick>
+                
+            </control>
+            
+            <!-- hide discart from osd - note: slim osd only has discart at music playback-->
+            <control type="radiobutton" id="13062">
+                <include>SkinSettings_Button</include>
+                <label>31519</label>
+                <onclick>Skin.ToggleSetting(HideOSDDisc)</onclick>
+                <selected>Skin.HasSetting(HideOSDDisc)</selected>
+				<visible>!Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+            <control type="radiobutton" id="13065">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31661]</label>
+                <onclick>Skin.ToggleSetting(osdgradientstyle)</onclick>
+                <selected>Skin.HasSetting(osdgradientstyle)</selected>
+                
+				<visible>!Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+            <!-- Volume Indicator Style -->
+            <control type="button" id="31809">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31809]</label>
+                <label2>$INFO[Skin.String(volumestyle.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=volumestyle,header=$LOCALIZE[31809])</onclick>
+				<visible>!Skin.HasSetting(LowPerformanceMode)</visible>
+            </control>
+            
+            <!-- Video playback -->
+            <control type="label" id="13050">
+                <include>SkinSettings_Header</include>
+                <label>31745</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<!-- Toggle Plot - OSDPanelModern, OSDPanelModernSlim, + whole info OSDPanelNetflix -->
+            <control type="radiobutton" id="13052">
+                <description>enable info on osd</description>
+                <include>SkinSettings_Button</include>
+                <label>31133</label><!-- 31133 -->
+                <onclick>Skin.ToggleSetting(EnableOSDInfo)</onclick>
+                <selected>Skin.HasSetting(EnableOSDInfo)</selected>
+            </control>
+			
+            <control type="button" id="13054">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31230]</label>
+                <label2>$INFO[skin.string(SkinHelper.ShowInfoAtPlaybackStart)] $LOCALIZE[31231]</label2>
+                <visible>!Skin.HasSetting(LowPerformanceMode)</visible>
+                <onclick>Skin.SetNumeric(SkinHelper.ShowInfoAtPlaybackStart)</onclick>
+            </control>
+            <control type="radiobutton" id="13058">
+                <include>SkinSettings_Button</include>
+                <label>31259</label>
+                <onclick>Skin.ToggleSetting(OSDShowInfoOnPause)</onclick>
+                <selected>Skin.HasSetting(OSDShowInfoOnPause)</selected>
+            </control>
+            <control type="radiobutton" id="31795">
+                <include>SkinSettings_Button</include>
+                <label>31795</label>
+                <onclick>Skin.ToggleSetting(SeekPanelOnPause)</onclick>
+                <selected>Skin.HasSetting(SeekPanelOnPause)</selected>
+                <visible>!Skin.HasSetting(OSDShowInfoOnPause)</visible>
+            </control>
+            <control type="button" id="31662">
+                <description>Default OSD button</description>
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31662]</label>
+                <label2>$INFO[Skin.String(defaultosdbutton_video.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=defaultosdbutton_video,header=$LOCALIZE[31662])</onclick>
+            </control>
+            <control type="button" id="31663">
+                <description>Default OSD button</description>
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31663]</label>
+                <label2>$INFO[Skin.String(defaultosdbutton_livetv.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=defaultosdbutton_livetv,header=$LOCALIZE[31663])</onclick>
+            </control>
+            <control type="radiobutton" id="13057">
+                <include>SkinSettings_Button</include>
+                <label>31256</label>
+                <onclick>Skin.ToggleSetting(OSDLargeSeekingLabel)</onclick>
+                <selected>Skin.HasSetting(OSDLargeSeekingLabel)</selected>
+            </control>
+            <control type="radiobutton" id="13059">
+                <include>SkinSettings_Button</include>
+                <label>31325</label>
+                <onclick>Skin.ToggleSetting(ShowWeatherVideoInfoOSD)</onclick>
+                <selected>Skin.HasSetting(ShowWeatherVideoInfoOSD)</selected>
+                
+            </control>
+			<control type="radiobutton" id="13068">
+                <include>SkinSettings_Button</include>
+                <label>Show Clock and Remaining Time in OSD</label>
+                <onclick>Skin.ToggleSetting(ShowClockRemainingTimeNetflixOSD)</onclick>
+                <selected>Skin.HasSetting(ShowClockRemainingTimeNetflixOSD)</selected>
+                
+				<visible>Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+            <control type="radiobutton" id="13067">
+                <include>SkinSettings_Button</include>
+                <label>31807</label>
+                <onclick>Skin.ToggleSetting(EnableBufferingProgressOSD)</onclick>
+                <selected>Skin.HasSetting(EnableBufferingProgressOSD)</selected>
+                
+            </control>
+			<control type="button" id="13063">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31629]</label>
+                <label2>$INFO[skin.string(SkinHelper.AutoCloseVideoOSD)] $LOCALIZE[31231]</label2>
+                <onclick>Skin.SetNumeric(SkinHelper.AutoCloseVideoOSD)</onclick>
+            </control>
+            <!-- style for codec info -->
+            <control type="button" id="13064">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31632]</label>
+                <label2>$INFO[Skin.String(osdmediaflagsstyle.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=osdmediaflagsstyle,header=$LOCALIZE[31632])</onclick>
+                
+            </control>
+            <!--clearart on osd -->
+            <control type="radiobutton" id="31733">
+                <include>SkinSettings_Button</include>
+                <label>31733</label>
+                <onclick>Skin.ToggleSetting(OSDShowClearArt)</onclick>
+                <selected>Skin.HasSetting(OSDShowClearArt)</selected>
+            </control>
+			<!--clearlogo on osd -->
+            <control type="radiobutton" id="36539">
+                <include>SkinSettings_Button</include>
+                <label>Disable Clearlogo on pause</label>
+                <onclick>Skin.ToggleSetting(OSDShowClearLogo)</onclick>
+                <selected>Skin.HasSetting(OSDShowClearLogo)</selected>
+                <visible>Skin.HasSetting(UseNetflixOSDPanel)</visible>
+            </control>
+			<!-- disable subtitles on video start -->
+			<control type="radiobutton" id="8012">
+                <include>SkinSettings_Button</include>
+                <label>31244</label>
+                <onclick>Skin.ToggleSetting(DisableSubtitles)</onclick>
+                <selected>Skin.HasSetting(DisableSubtitles)</selected>
+            </control>
+            <!-- hide playback controls -->
+            <control type="radiobutton" id="31819">
+                <include>SkinSettings_Button</include>
+                <label>31819</label>
+                <onclick>Skin.ToggleSetting(OSDDisablePlaybackControls)</onclick>
+                <selected>Skin.HasSetting(OSDDisablePlaybackControls)</selected>
+            </control>
+            <!-- UpNext Skin related Settings 31670**-->
+            <control type="label" id="3167000">
+                <include>SkinSettings_Header</include>
+                <label>$ADDON[service.upnext 30008] $LOCALIZE[10035]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+			<!-- Use Upnext_diffused_art -->
+            <control type="radiobutton" id="3100702">
+                <width>100%</width>
+				<align>left</align>
+				<height>100</height>
+				<font>arial26</font>
+				<textoffsetx>40</textoffsetx>
+				<textwidth>950</textwidth>
+				<wrapmultiline>true</wrapmultiline>
+                <label>Apply Panel Color Inking and use $ADDON[script.skin.helper.colorpicker 32049] for Artwork[CR][I]("$ADDON[service.upnext 30024]" Pop-Up + Tringle Layout)[/I]</label>
+                <onclick>Skin.ToggleSetting(Upnext_diffused_art)</onclick>
+                <selected>Skin.HasSetting(Upnext_diffused_art)</selected>
+				<visible>System.HasAddon(service.upnext)</visible>
+            </control>
+			<!-- Use Upnext_diffused_art -->
+			<control type="radiobutton" id="3100710">
+                <width>100%</width>
+				<align>left</align>
+				<height>100</height>
+				<font>arial26</font>
+				<textoffsetx>40</textoffsetx>
+				<textwidth>950</textwidth>
+				<wrapmultiline>true</wrapmultiline>
+                <label>Apply Panel Color Inking and use $ADDON[script.skin.helper.colorpicker 32049] for whole Panel [CR][I](instead of just inking the left border on a black Triangle panel)[/I]</label>
+                <onclick>Skin.ToggleSetting(UpNext_Use_Inked_Panel)</onclick>
+                <selected>Skin.HasSetting(UpNext_Use_Inked_Panel)</selected>
+				<visible>Skin.String(upnext_fancy,upn_fancy_triangle)</visible>
+				<visible>System.HasAddon(service.upnext)</visible>
+            </control>
+			<!-- Upnext Show Countdown Image on thumb -->
+			<control type="radiobutton" id="3100705">
+                <include>SkinSettings_Button</include>
+                <label>Show Countdown Image on Thumb in "$ADDON[service.upnext 30008]" Pop-Up </label>
+                <onclick>Skin.ToggleSetting(UpNext_ShowCountdownAtThumb)</onclick>
+                <selected>Skin.HasSetting(UpNext_ShowCountdownAtThumb)</selected>
+				<visible>!Skin.String(upnext_fancy,upn_fancy_def)</visible>
+				<visible>System.HasAddon(service.upnext)</visible>
+            </control>
+			<!-- Choose Fancy Layout -->
+			<control type="button" id="3100703">
+                <include>SkinSettings_Button</include>
+                <label>"$ADDON[service.upnext 30008]" : $LOCALIZE[22080] $ADDON[service.upnext 30039] Layout</label>
+				<label2>$INFO[Skin.String(upnext_fancy.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=upnext_fancy,header=Choose Fancy Layout)</onclick>
+				<visible>System.HasAddon(service.upnext)</visible>
+			</control>
+			<!-- Choose Simple Layout -->
+            <control type="button" id="3100704">
+                <include>SkinSettings_Button</include>
+                <label>"$ADDON[service.upnext 30008]" : $LOCALIZE[22080] $ADDON[service.upnext 30038] Layout</label>
+				<label2>$INFO[Skin.String(upnext_simple.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=upnext_simple,header=Choose Simple Layout)</onclick>
+				<visible>System.HasAddon(service.upnext)</visible>
+			</control>
+			
+			<!-- up next colors -->
+			<!-- $INFO[Skin.String(upnext_panel)]-->
+			 <include content="SkinSettings_ColorButton">
+				<param name="id" value="3100708" />
+				<param name="label" value="upnext_panel" />
+				<param name="skinsetting" value="upnext_panel" />
+				<param name="visible" value="System.HasAddon(service.upnext) + [!Skin.String(upnext_fancy,upn_fancy_def) | !Skin.String(upnext_simple,upn_simple_addondefault)]" />
+			</include>
+			<!-- $INFO[Skin.String(upnext_text)]-->
+				<include content="SkinSettings_ColorButton">
+				<param name="id" value="3100706" />
+				<param name="label" value="upnext_text" />
+				<param name="skinsetting" value="upnext_text" />
+				<param name="visible" value="System.HasAddon(service.upnext) + [!Skin.String(upnext_fancy,upn_fancy_def) | !Skin.String(upnext_simple,upn_simple_addondefault)]" />
+			</include>
+			<!-- $INFO[Skin.String(upnext_text_secondary)] -->
+			<include content="SkinSettings_ColorButton">
+				<param name="id" value="3100709" />
+				<param name="label" value="upnext_text_secondary" />
+				<param name="skinsetting" value="upnext_text_secondary" />
+				<param name="visible" value="System.HasAddon(service.upnext) + [[!Skin.String(upnext_fancy,upn_fancy_triangle) + !Skin.String(upnext_fancy,upn_fancy_def)] | Skin.String(upnext_simple,upn_simple_skindefault)]" />
+			</include>
+			
+		    <!-- music playback -->
+            <control type="label" id="31670">
+                <include>SkinSettings_Header</include>
+                <label>31670</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="button" id="31664">
+                <description>Default OSD button</description>
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31664]</label>
+                <label2>$INFO[Skin.String(defaultosdbutton_music.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=defaultosdbutton_music,header=$LOCALIZE[31664])</onclick>
+            </control>
+			<control type="button" id="31921">
+                <description>Default OSD button</description>
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31921]</label>
+                <label2>$INFO[Skin.String(defaultosdbutton_musicPVR.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=defaultosdbutton_musicPVR,header=$LOCALIZE[31921])</onclick>
+            </control>
+            <control type="radiobutton" id="5143">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31179]</label>
+                <onclick>Skin.ToggleSetting(FullscreenMusic)</onclick>
+                <selected>Skin.HasSetting(FullscreenMusic)</selected>
+            </control>
+            <control type="radiobutton" id="13055">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31232]</label>
+                <onclick>Skin.ToggleSetting(AlwaysShowMusicInfo)</onclick>
+                <selected>Skin.HasSetting(AlwaysShowMusicInfo)</selected>
+            </control>
+            <control type="button" id="5153">
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31087</label>
+                <label2 fallback="None">$INFO[Skin.String(LyricScript_Path)]</label2>
+                <onclick condition="!Skin.String(LyricScript_Path)">Skin.SetAddon(LyricScript_Path,xbmc.python.lyrics)</onclick>
+                <onclick condition="Skin.String(LyricScript_Path)">Addon.OpenSettings($INFO[Skin.String(LyricScript_Path)])</onclick>
+            </control>
+            <control type="radiobutton" id="5161">
+                <description>disable backgroundoverlay lyrics dialog</description>
+                <include>SkinSettings_Button</include>
+                <label>31332</label>
+                <onclick>Skin.ToggleSetting(DisableLyricsOverlay)</onclick>
+                <selected>Skin.HasSetting(DisableLyricsOverlay)</selected>
+                <visible>System.HasAddon(script.cu.lrclyrics)</visible>
+            </control>
+            <control type="button" id="5157">
+                <description>Artist Slideshow in musicplayer</description>
+                <include>SkinSettings_Button</include>
+                <label>31341</label>
+                <label2>$INFO[Skin.String(MusicArtistFanart.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=MusicArtistFanart,header=$LOCALIZE[31341])</onclick>
+            </control>
+            <control type="button" id="31665">
+                <description>Artist Logo in musicplayer</description>
+                <include>SkinSettings_Button</include>
+                <label>31665</label>
+                <label2>$INFO[Skin.String(MusicArtistLogo.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=MusicArtistLogo,header=$LOCALIZE[31665])</onclick>
+            </control>
+            <control type="radiobutton" id="31640">
+                <description>Artist Bio in musicplayer</description>
+                <include>SkinSettings_Button</include>
+                <label>31640</label>
+                <onclick>Skin.ToggleSetting(enableArtistBio)</onclick>
+                <selected>Skin.HasSetting(enableArtistBio)</selected>
+                
+            </control>
+            <control type="button" id="31824">
+                <description>Fallback image music playback</description>
+                <include>SkinSettings_Button</include>
+                <label>31824</label>
+                <label2>$INFO[Skin.String(MusicBackground.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=selectimage,skinstring=MusicBackground,header=$LOCALIZE[31824],allowmulti=true,resourceaddon=resource.images.skinbackgrounds,skinhelperbackgrounds=true)</onclick>
+            </control>
+            <control type="radiobutton" id="5170">
+                <description>Animate Music background</description>
+                <include>SkinSettings_Button</include>
+                <label>31617</label>
+                <onclick>Skin.ToggleSetting(animateMusicArt)</onclick>
+                <selected>Skin.HasSetting(animateMusicArt)</selected>
+            </control>
+            <control type="radiobutton" id="31732">
+                <description>scrolling music text</description>
+                <include>SkinSettings_Button</include>
+                <label>31732</label>
+                <onclick>Skin.ToggleSetting(MusicOSDScrollingTitles)</onclick>
+                <selected>Skin.HasSetting(MusicOSDScrollingTitles)</selected>
+            </control>
+            <control type="radiobutton" id="31715">
+                <description>Disable screensaver on music playback</description>
+                <include>SkinSettings_Button</include>
+                <label>31715</label>
+                <onclick>Skin.ToggleSetting(SkinHelper.DisableScreenSaverOnFullScreenMusic)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.DisableScreenSaverOnFullScreenMusic)</selected>
+            </control>
+            <control type="button" id="130631">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31629]</label>
+                <label2>$INFO[skin.string(SkinHelper.AutoCloseMusicOSD)] $LOCALIZE[31231]</label2>
+                <onclick>Skin.SetNumeric(SkinHelper.AutoCloseMusicOSD)</onclick>
+            </control>
+            
+            <!-- Now playing options -->
+            <control type="label" id="31669">
+                <include>SkinSettings_Header</include>
+                <label>31669</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="5141">
+                <include>SkinSettings_Button</include>
+                <label>31140</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingBackground)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingBackground)</selected>
+                
+            </control>
+            <control type="radiobutton" id="31734">
+                <include>SkinSettings_Button</include>
+                <label>31734</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingMusicBackground)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingMusicBackground)</selected>
+                
+            </control>
+            <control type="radiobutton" id="5142">
+                <include>SkinSettings_Button</include>
+                <label>31596</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingInfoBar)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingInfoBar)</selected>
+            </control>
+            <control type="radiobutton" id="31634">
+                <include>SkinSettings_Button</include>
+                <label>31634</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingDiscArt)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingDiscArt)</selected>
+                <visible>!Skin.HasSetting(DisableNowPlayingInfoBar)</visible>
+            </control>
+            <control type="radiobutton" id="31736">
+                <include>SkinSettings_Button</include>
+                <label>31736</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingClearArt)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingClearArt)</selected>
+                <visible>!Skin.HasSetting(DisableNowPlayingInfoBar)</visible>
+            </control>
+			<control type="radiobutton" id="32569">
+                <include>SkinSettings_Button</include>
+                <label>Disable clock in Now Playing Info Bar</label>
+                <onclick>Skin.ToggleSetting(DisableNowPlayingClock)</onclick>
+                <selected>Skin.HasSetting(DisableNowPlayingClock)</selected>
+                <visible>!Skin.HasSetting(DisableNowPlayingInfoBar)</visible>
+            </control>
+            
+         </control>
+		<!--scrollbar for osd settings-->
+        <control type="scrollbar" id="316"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>16000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),16)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_OSD_Colors">
+         <!-- media library views colors -->
+        <control type="label" id="69567">
+            <include>SkinSettings_Header</include>
+            <label>$LOCALIZE[31668]</label>
+            
+        </control>
+
+        <!--OSDPanelColor-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31473" />
+            <param name="label" value="$LOCALIZE[31473]" />
+            <param name="skinsetting" value="OSDPanelColor" />
+            <param name="visible" value="true" />
+        </include>
+         <!--osd text color 1 -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31478" />
+            <param name="label" value="$LOCALIZE[31478]" />
+            <param name="skinsetting" value="OSDPrimaryTextColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd text color 1 shadow -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31479" />
+            <param name="label" value="$LOCALIZE[31479]" />
+            <param name="skinsetting" value="OSDPrimaryTextShadowColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd text color 2 -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31480" />
+            <param name="label" value="$LOCALIZE[31480]" />
+            <param name="skinsetting" value="OSDSecondaryTextColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd text color 2 shadow -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31481" />
+            <param name="label" value="$LOCALIZE[31481]" />
+            <param name="skinsetting" value="OSDSecondaryTextShadowColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd progress bar background color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31482" />
+            <param name="label" value="$LOCALIZE[31482]" />
+            <param name="skinsetting" value="OSDProgressBarBackgroundColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd progress bar border color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31547" />
+            <param name="label" value="$LOCALIZE[31547]" />
+            <param name="skinsetting" value="OSDProgressBarBorderColor" />
+            <param name="visible" value="!Skin.HasSetting(UseSlimOSDPanel)" />
+        </include>
+        <!--osd progress bar color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31483" />
+            <param name="label" value="$LOCALIZE[31483]" />
+            <param name="skinsetting" value="OSDProgressBarColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd progress bar cache color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31573" />
+            <param name="label" value="$LOCALIZE[31573]" />
+            <param name="skinsetting" value="OSDProgressBarCacheColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!--osd buttons color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31484" />
+            <param name="label" value="$LOCALIZE[31484]" />
+            <param name="skinsetting" value="OSDButtonsColor" />
+            <param name="visible" value="true" />
+        </include>
+         <!--osd buttons focus color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31485" />
+            <param name="label" value="$LOCALIZE[31485]" />
+            <param name="skinsetting" value="OSDButtonsFocusColor" />
+            <param name="visible" value="true" />
+        </include>
+		<!--OSD Buffering Spinner Color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31295" />
+            <param name="label" value="OSD Buffering Spinner Color" />
+            <param name="skinsetting" value="OSDBufferingSpinnerColor" />
+            <param name="visible" value="true" />
+        </include>
+        <!-- Lyrics diffuse panel -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31813" />
+            <param name="label" value="$LOCALIZE[31813]" />
+            <param name="skinsetting" value="LyricsOverlayColor" />
+            <param name="visible" value="!Skin.HasSetting(DisableLyricsOverlay)" />
+        </include>
+        <!-- Lyrics unfocused text -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31814" />
+            <param name="label" value="$LOCALIZE[31814]" />
+            <param name="skinsetting" value="LyricsTextColor" />
+        </include>
+        <!-- Lyrics unfocused text shadow -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31816" />
+            <param name="label" value="$LOCALIZE[31816]" />
+            <param name="skinsetting" value="LyricsTextShadowColor" />
+        </include>
+        <!-- Lyrics focused text -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31815" />
+            <param name="label" value="$LOCALIZE[31815]" />
+            <param name="skinsetting" value="LyricsFocusTextColor" />
+        </include>
+        <!-- Lyrics focused text shadow -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31817" />
+            <param name="label" value="$LOCALIZE[31817]" />
+            <param name="skinsetting" value="LyricsFocusTextShadowColor" />
+        </include>
+	</include>
+    
+    <include name="SkinSettings_PVR">
+        <!-- PVR -->
+        <control type="grouplist" id="18000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>18000</onup>
+            <ondown>18000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>316</onright>
+            <pagecontrol>316</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),18)</visible>
+            <!-- PVR appearance settings -->
+            <control type="label" id="13040">
+                <include>SkinSettings_Header</include>
+                <label>$LOCALIZE[31088]</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            
+            <!-- number of rows guide -->
+            <control type="button" id="13043">
+                <include>SkinSettings_Button</include>
+                <label>31245</label>
+                <label2>$INFO[Skin.String(GuideRows.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=GuideRows,header=$LOCALIZE[31245])</onclick>
+            </control>
+            <control type="radiobutton" id="13045">
+                <include>SkinSettings_Button</include>
+                <label>31239</label>
+                <onclick>Skin.ToggleSetting(UseAltEpgProgress)</onclick>
+                <onclick condition="Window.IsActive(tvguide)">ReloadSkin</onclick>
+                <selected>Skin.HasSetting(UseAltEpgProgress)</selected>
+            </control>
+            <control type="radiobutton" id="13046">
+                <description>no channel names in guide</description>
+                <include>SkinSettings_Button</include>
+                <label>31333</label>
+                <onclick>Skin.ToggleSetting(HideChannelNamesInGuide)</onclick>
+                <selected>Skin.HasSetting(HideChannelNamesInGuide)</selected>
+                <onclick condition="Window.IsActive(tvguide)">ReloadSkin</onclick>
+            </control>
+            <control type="radiobutton" id="31642">
+                <description>no channel numbers in guide</description>
+                <include>SkinSettings_Button</include>
+                <label>31642</label>
+                <onclick>Skin.ToggleSetting(HideChannelNumbersInGuide)</onclick>
+                <selected>Skin.HasSetting(HideChannelNumbersInGuide)</selected>
+            </control>
+            <control type="radiobutton" id="31673">
+                <description>no channel logos in guide</description>
+                <include>SkinSettings_Button</include>
+                <label>31673</label>
+                <onclick>Skin.ToggleSetting(HideChannelLogosInGuide)</onclick>
+                <selected>Skin.HasSetting(HideChannelLogosInGuide)</selected>
+            </control>
+	    <control type="radiobutton" id="31920">
+		<description>Use Alternate Episode Name Variable</description>
+		<include>SkinSettings_Button</include>
+		<label>31920</label>
+		<onclick>Skin.ToggleSetting(AlternateEpisodeName)</onclick>
+		<selected>Skin.HasSetting(AlternateEpisodeName)</selected>
+	    </control>
+            <control type="radiobutton" id="13047">
+                <description>Show video preview in PVR section</description>
+                <include>SkinSettings_Button</include>
+                <label>31338</label>
+                <onclick>Skin.ToggleSetting(PVRShowPreview)</onclick>
+                <selected>Skin.HasSetting(PVRShowPreview)</selected>
+            </control>
+            <control type="radiobutton" id="13048">
+                <description>Back button in guide opens sideblade menu</description>
+                <include>SkinSettings_Button</include>
+                <label>31560</label>
+                <onclick>Skin.ToggleSetting(PVRGuideBackSideblade)</onclick>
+                <selected>Skin.HasSetting(PVRGuideBackSideblade)</selected>
+            </control>
+            <control type="radiobutton" id="13049">
+                <description>Enable mini guide on fullscreen live tv</description>
+                <include>SkinSettings_Button</include>
+                <label>31616</label>
+                <onclick>Skin.ToggleSetting(pvrGuideOnFullscreenVideo)</onclick>
+                <selected>Skin.HasSetting(pvrGuideOnFullscreenVideo)</selected>
+            </control>
+            <control type="radiobutton" id="31792">
+                <description>Enable small PVR channels OSD</description>
+                <include>SkinSettings_Button</include>
+                <label>31792</label>
+                <onclick>Skin.ToggleSetting(small_pvrchannelsosd)</onclick>
+                <selected>Skin.HasSetting(small_pvrchannelsosd)</selected>
+            </control>
+            <control type="radiobutton" id="31776">
+                <description>Highlight channel row in guide</description>
+                <include>SkinSettings_Button</include>
+                <label>31776</label>
+                <onclick>Skin.ToggleSetting(pvrGuideHighlightChannel)</onclick>
+                <selected>Skin.HasSetting(pvrGuideHighlightChannel)</selected>
+            </control>
+            <control type="radiobutton" id="31708">
+                <description>Enable artwork lookups for PVR</description>
+                <include>SkinSettings_Button</include>
+                <label>31708</label>
+                <onclick>Skin.ToggleSetting(SkinHelper.EnablePVRThumbs)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.EnablePVRThumbs)</selected>
+            </control>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="31709" />
+                <param name="label" value="31709" />
+                <param name="action" value="Addon.OpenSettings(script.module.metadatautils)" />
+                <param name="visible" value="Skin.HasSetting(SkinHelper.EnablePVRThumbs)" />
+            </include>
+            <control type="radiobutton" id="13041">
+                <include>SkinSettings_Button</include>
+                <label>31237</label>
+                <onclick>Skin.ToggleSetting(ShowEpgGenreColors)</onclick>
+                <selected>Skin.HasSetting(ShowEpgGenreColors)</selected>
+            </control>
+            <control type="radiobutton" id="31677">
+                <include>SkinSettings_Button</include>
+                <label>31677</label>
+                <onclick>Skin.ToggleSetting(CustomEPGGenreImages)</onclick>
+                <onclick condition="!Skin.HasSetting(CustomEPGGenreImages)">RunScript(script.skin.helper.service,action=dialogok,header=$LOCALIZE[31677],message=$LOCALIZE[31678])</onclick>
+                <selected>Skin.HasSetting(CustomEPGGenreImages)</selected>
+                <visible>Skin.HasSetting(ShowEpgGenreColors)</visible>
+            </control>
+            <control type="button" id="31676">
+                <include>SkinSettings_Button</include>
+                <label>31676</label>
+                <label2>$INFO[Skin.String(pvrgenretype.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=pvrgenretype,header=$LOCALIZE[31676])</onclick>
+                <visible>Skin.HasSetting(ShowEpgGenreColors) + Skin.HasSetting(CustomEPGGenreImages)</visible>
+            </control>
+            <control type="radiobutton" id="31825">
+                <include>SkinSettings_Button</include>
+                <label>31825</label>
+                <onclick>Skin.ToggleSetting(NoPvrArtOSD)</onclick>
+                <selected>Skin.HasSetting(NoPvrArtOSD)</selected>
+                <visible>Skin.HasSetting(SkinHelper.EnablePVRThumbs)</visible>
+            </control>
+            
+        </control>
+				
+    </include>
+    
+    <include name="SkinSettings_PVR_Colors">
+         <!-- PVR Guide colors -->
+        <control type="label" id="69568">
+            <include>SkinSettings_Header</include>
+            <label>$LOCALIZE[31088]</label>
+        </control>
+
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31777" />
+            <param name="label" value="$LOCALIZE[31777]" />
+            <param name="skinsetting" value="PVRGuideItemColorUnfocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31778" />
+            <param name="label" value="$LOCALIZE[31778]" />
+            <param name="skinsetting" value="PVRGuideItemColorFocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31779" />
+            <param name="label" value="$LOCALIZE[31779]" />
+            <param name="skinsetting" value="PVRGuideItemTextColorUnfocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31780" />
+            <param name="label" value="$LOCALIZE[31780]" />
+            <param name="skinsetting" value="PVRGuideItemTextColorFocus" />
+        </include>
+         
+
+    </include>
+    
+    <include name="SkinSettings_Shortcuts">
+        <!-- configure menu -->
+        <control type="grouplist" id="6000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>6000</onup>
+            <ondown>6000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright></onright>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),9)</visible>
+            <control type="label" id="6001">
+                <include>SkinSettings_Header</include>
+                <label>31167</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="textbox" id="6002">
+                <width>100%</width>
+                <height min="160">auto</height>
+                <font>Reg25</font>
+                <posy>60</posy>
+                <label>31168</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+                <shadowcolor>black</shadowcolor>
+                <align>left</align>
+                <aligny>top</aligny>
+            </control>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="6003" />
+                <param name="label" value="31014" />
+                <param name="action" value="RunScript(script.skinshortcuts,type=manage&amp;group=mainmenu)" />
+                <param name="visible" value="true" />
+            </include>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="96008" />
+                <param name="label" value="31204" />
+                <param name="action" value="RunScript(script.skinshortcuts,type=manage&amp;group=powermenu)" />
+                <param name="action2" value="SetProperty(powermenu, active, Home)" />
+                <param name="visible" value="true" />
+            </include>
+			 <!--lock hub widgets-->
+            <control type="radiobutton" id="31205">
+                <include>SkinSettings_Button</include>
+                <label>Lock Widgets in Hubs</label>
+                <onclick>Skin.ToggleSetting(LockHubWidgets)</onclick>
+                <selected>Skin.HasSetting(LockHubWidgets)</selected>
+            </control>
+            <!-- empty label -->
+            <control type="label" id="6004">
+                <height>20</height>
+				<label></label>
+            </control>
+            <control type="label" id="6005">
+                <include>SkinSettings_Header</include>
+                <label>31170</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="textbox" id="6006">
+                <width>100%</width>
+                <height min="220">auto</height>
+                <font>Reg25</font>
+                <posy>60</posy>
+                <label>31171</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+                <shadowcolor>black</shadowcolor>
+                <align>left</align>
+                <aligny>top</aligny>
+            </control>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="6007" />
+                <param name="label" value="$ADDON[script.skinshortcuts 32028]" />
+                <param name="action" value="RunScript(script.skinshortcuts,type=resetall)" />
+                <param name="visible" value="true" />
+            </include>
+             </control>
+    </include>
+    
+    <include name="SkinSettings_ColorThemes">
+        <!-- color themes -->
+        <control type="grouplist" id="15000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>15000</onup>
+            <ondown>15000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>313</onright>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),15)</visible>
+
+            <control type="label" id="15001">
+                <include>SkinSettings_Header</include>
+                <label>31463</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="textbox" id="15002">
+                <description></description>
+                <width>1200</width>
+                <align>justify</align>
+                <label>31464</label>
+                <height>auto</height>
+                <font>Reg26</font>
+            </control>
+            <control type="label" id="15003">
+                <height>10</height>
+            </control>
+            <control type="button" id="15004">
+                <description>Select Theme</description>
+                <label>31800</label>
+                <include>SkinSettings_Button</include>
+                <onclick>RunScript(script.skin.helper.skinbackup,action=colorthemes)</onclick>
+                <onclick condition="!System.HasAddon(script.skin.helper.skinbackup)">RunPlugin(plugin://script.skin.helper.skinbackup)</onclick>
+                <onclick>ClearProperty(startupDone,home)</onclick>
+            </control>
+            <control type="label" id="15030">
+                <height>40</height>
+            </control>
+            <control type="label" id="15031">
+                <include>SkinSettings_Header</include>
+                <label>31589</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="textbox" id="15032">
+                <description></description>
+                <width>1200</width>
+                <align>justify</align>
+                <label>31590</label>
+                <height>auto</height>
+                <font>Reg26</font>
+            </control>
+            <control type="label" id="125003">
+                <height>40</height>
+            </control>
+            <control type="radiobutton" id="15033">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31589]</label>
+                <onclick condition="System.HasAddon(script.skin.helper.skinbackup)">Skin.ToggleSetting(SkinHelper.EnableDayNightThemes)</onclick>
+                <onclick condition="!System.HasAddon(script.skin.helper.skinbackup)">RunPlugin(plugin://script.skin.helper.skinbackup)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.EnableDayNightThemes)</selected>
+            </control>
+            <control type="button" id="15034">
+                <include>SkinSettings_Button</include>
+                <description>Select Theme for day</description>
+                <label>$LOCALIZE[31591]: $INFO[Skin.String(SkinHelper.ColorTheme.Day.label)]</label>
+                <onclick>RunScript(script.skin.helper.skinbackup,action=daynighttheme,daynight=day)</onclick>
+                <onclick condition="!System.HasAddon(script.skin.helper.skinbackup)">RunPlugin(plugin://script.skin.helper.skinbackup)</onclick>
+                <visible>Skin.HasSetting(SkinHelper.EnableDayNightThemes)</visible>
+            </control>
+            <control type="button" id="15035">
+                <include>SkinSettings_Button</include>
+                <description>Select Theme for night</description>
+                <label>$LOCALIZE[31592]: $INFO[Skin.String(SkinHelper.ColorTheme.Night.label)]</label>
+                <onclick>RunScript(script.skin.helper.skinbackup,action=daynighttheme,daynight=night)</onclick>
+                <onclick condition="!System.HasAddon(script.skin.helper.skinbackup)">RunPlugin(plugin://script.skin.helper.skinbackup)</onclick>
+                <visible>Skin.HasSetting(SkinHelper.EnableDayNightThemes)</visible>
+            </control>
+
+            <!-- Default palette for Color Picker -->
+            <control type="label" id="15005">
+                <height>40</height>
+            </control>
+            <control type="label" id="15006">
+                <include>SkinSettings_Header</include>
+                <label>31768</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="textbox" id="15007">
+                <description></description>
+                <width>1200</width>
+                <align>justify</align>
+                <label>31769</label>
+                <height>auto</height>
+                <font>Reg26</font>
+            </control>
+            <control type="button" id="15008">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31767]</label>
+                <label2>$INFO[skin.string(defaultcolorpalette)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=defaultcolorpalette,header=$LOCALIZE[31767])</onclick>
+            </control>
+			
+        </control>
+    </include>
+    
+    <include name="SkinSettings_CustomColors">
+        <!-- custom colors -->
+        <control type="grouplist" id="20000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>20000</onup>
+            <ondown>20000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>326</onright>
+            <pagecontrol>326</pagecontrol>
+            <orientation>vertical</orientation>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),20)</visible>
+
+            <!-- all color settings -->
+            <include>SkinSettings_General_Colors</include>
+            <include>SkinSettings_OSD_Colors</include>
+            <include>SkinSettings_Library_Colors</include>
+            <include condition="PVR.HasTVChannels">SkinSettings_PVR_Colors</include>
+     
+        </control>
+        <!--scrollbar -->
+        <control type="scrollbar" id="326"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>20000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),20)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_Backup">
+        <!-- advanced settings -->
+        <control type="grouplist" id="8000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>8000</onup>
+            <ondown>8000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>313</onright>
+            <orientation>vertical</orientation>
+            <pagecontrol>313</pagecontrol>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),14)</visible>
+            <!-- backup and restore -->
+            <control type="label" id="8001">
+                <include>SkinSettings_Header</include>
+                <label>31271</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8005" />
+                <param name="label" value="31801" />
+                <param name="action" value="RunAddon(script.skin.helper.skinbackup)" />
+                <param name="visible" value="System.HasAddon(script.skin.helper.skinbackup)" />
+            </include>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8002" />
+                <param name="label" value="31272" />
+                <param name="action" value="RunScript(script.skin.helper.skinbackup,action=backup)" />
+                <param name="visible" value="System.HasAddon(script.skin.helper.skinbackup)" />
+            </include>
+
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8003" />
+                <param name="label" value="31273" />
+                <param name="action" value="RunScript(script.skin.helper.skinbackup,action=RESTORE)" />
+                <param name="visible" value="System.HasAddon(script.skin.helper.skinbackup)" />
+            </include>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8004" />
+                <param name="label" value="31274" />
+                <param name="action" value="RunScript(script.skin.helper.skinbackup,action=RESET)" />
+                <param name="visible" value="System.HasAddon(script.skin.helper.skinbackup)" />
+            </include>
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8006" />
+                <param name="label" value="31801" />
+                <param name="action" value="RunPlugin(plugin://script.skin.helper.skinbackup)" />
+                <param name="visible" value="!System.HasAddon(script.skin.helper.skinbackup)" />
+            </include>
+
+        </control>
+        <!--scrollbar for advanced settings-->
+        <control type="scrollbar" id="313"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>8000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),14)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_General">
+        <!--general settings-->
+        <control type="grouplist" id="5000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>5000</onup>
+            <ondown>5000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>312</onright>
+            <orientation>vertical</orientation>
+            <pagecontrol>312</pagecontrol>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),6)</visible>
+
+            <!-- general -->
+            <control type="label" id="5136">
+                <include>SkinSettings_Header</include>
+                <label>31005</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="radiobutton" id="5147">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31209]</label>
+                <onclick>Skin.ToggleSetting(EnableTouchSupport)</onclick>
+                <onclick>ReloadSkin</onclick>
+                <selected>Skin.HasSetting(EnableTouchSupport)</selected>
+            </control>
+            <control type="radiobutton" id="5149">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31215]</label>
+                <onclick>Skin.ToggleSetting(HideMouseCursor)</onclick>
+                <selected>Skin.HasSetting(HideMouseCursor)</selected>
+                <visible>System.Platform.Windows + Skin.HasSetting(EnableTouchSupport)</visible>
+            </control>
+            <control type="radiobutton" id="5150">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31292]</label>
+                <onclick>Skin.ToggleSetting(HideBatteryStatus)</onclick>
+                <selected>Skin.HasSetting(HideBatteryStatus)</selected>
+                <visible>Skin.HasSetting(EnableTouchSupport) + ![Skin.String(HomeLayout, simplever) | Skin.String(HomeLayout, simplever_tiles) | Skin.HasSetting(CompactHeader)]</visible>
+            </control>
+            <control type="radiobutton" id="5144">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31726]</label>
+                <onclick condition="!Skin.String(AutoStartPlayList)">Skin.SetFile(AutoStartPlayList,,special://MusicPlaylists/)</onclick>
+                <onclick condition="Skin.String(AutoStartPlayList)">Skin.Reset(AutoStartPlayList)</onclick>
+                <selected>Skin.String(AutoStartPlayList)</selected>
+            </control>
+            <control type="radiobutton" id="5159">
+                <description>Kiosk mode</description>
+                <include>SkinSettings_Button</include>
+                <label>31318</label>
+                <onclick>Skin.ToggleSetting(KioskMode.Enabled)</onclick>
+                <selected>Skin.HasSetting(KioskMode.Enabled)</selected>
+            </control>
+			<!-- check, merge visibility into touch support ? -->
+            <control type="radiobutton" id="5162">
+                <description>show scrollbars</description>
+                <include>SkinSettings_Button</include>
+                <label>31344</label>
+                <onclick>Skin.ToggleSetting(alwaysShowScrollbars)</onclick>
+                <selected>Skin.HasSetting(alwaysShowScrollbars)</selected>
+                <visible>!Skin.HasSetting(DisableScrollbars)</visible>
+            </control>
+			<!-- check, really needed ? -->
+            <control type="radiobutton" id="31764">
+                <description>show scrollbars</description>
+                <include>SkinSettings_Button</include>
+                <label>31764</label>
+                <onclick>Skin.ToggleSetting(DisableScrollbars)</onclick>
+                <selected>Skin.HasSetting(DisableScrollbars)</selected>
+            </control>
+            <control type="radiobutton" id="31720">
+                <description>rounded panels</description>
+                <include>SkinSettings_Button</include>
+                <label>31720</label>
+                <onclick>Skin.ToggleSetting(smallContextMenu)</onclick>
+                <selected>Skin.HasSetting(smallContextMenu)</selected>
+                
+            </control>
+			<!-- check, improve?-->
+            <control type="radiobutton" id="5163">
+                <description>use extended weather screen</description>
+                <include>SkinSettings_Button</include>
+                <label>31451</label>
+                <onclick>Skin.ToggleSetting(useExtendedWeatherScreen)</onclick>
+                <selected>Skin.HasSetting(useExtendedWeatherScreen)</selected>
+            </control>
+            <!--no footer, check homelayouts and divide from home and lib ?-->
+            <control type="radiobutton" id="13714">
+                <include>SkinSettings_Button</include>
+                <label>31029</label>
+                <onclick>Skin.ToggleSetting(NoFooterBar)</onclick>
+                <selected>Skin.HasSetting(NoFooterBar)</selected>
+            </control>
+            <!--LOADING SPINNER-->
+            <control type="button" id="5165">
+                <include>SkinSettings_Button</include>
+                <label>31504</label>
+                <label2>$INFO[Skin.String(SkinHelper.SpinnerTexture.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=BUSYTEXTURE)</onclick>
+            </control>
+            <!--LOADING SPINNER COLOR-->
+            <include content="SkinSettings_ColorButton">
+                <param name="id" value="5166" />
+                <param name="label" value="$LOCALIZE[31505]" />
+                <param name="skinsetting" value="SpinnerTexture.Color" />
+            </include>
+
+            <!--LOADING SPINNER DIM-->
+            <control type="radiobutton" id="5167">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31506]</label>
+                <onclick>Skin.ToggleSetting(SpinnerDimScreen)</onclick>
+                <selected>Skin.HasSetting(SpinnerDimScreen)</selected>
+            </control>
+            <!--thumbs label alignment, check localiced - tag center-left,split widget - lib? -->
+            <control type="radiobutton" id="5168">
+                <include>SkinSettings_Button</include>
+                <label>$LOCALIZE[31600]</label>
+                <onclick>Skin.ToggleSetting(ThumbsLabelAlignmentCenter)</onclick>
+                <selected>Skin.HasSetting(ThumbsLabelAlignmentCenter)</selected>
+            </control>
+            <!--thumbs border size unfocused-->
+            <control type="button" id="31003">
+                <include>SkinSettings_Button</include>
+                <label>31003</label>
+                <label2>$INFO[Skin.String(thumbsborder_unfocused.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=thumbsborder_unfocused,header=$LOCALIZE[31003])</onclick>
+            </control>
+            <!--thumbs border size focused-->
+            <control type="button" id="31628">
+                <include>SkinSettings_Button</include>
+                <label>31628</label>
+                <label2>$INFO[Skin.String(thumbsborder_focused.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=thumbsborder_focused,header=$LOCALIZE[31003])</onclick>
+            </control>
+           <!-- header settings -->
+            <control type="label" id="31704">
+                <include>SkinSettings_Header</include>
+                <label>31704</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            <control type="button" id="31702">
+                <include>SkinSettings_Button</include>
+                <label>31702</label>
+                <label2>$INFO[Skin.String(general_header.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=general_header,header=$LOCALIZE[31702])</onclick>
+            </control>
+            <control type="button" id="31703">
+                <include>SkinSettings_Button</include>
+                <label>31703</label>
+                <label2>$INFO[Skin.String(home_header.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=home_header,header=$LOCALIZE[31703])</onclick>
+            </control>
+            
+            <!--compact header, check, merge into one, remove setting, diff is not worth it -->
+            <control type="radiobutton" id="31671">
+                <include>SkinSettings_Button</include>
+                <label>31671</label>
+                <onclick>Skin.ToggleSetting(CompactHeader)</onclick>
+                <selected>Skin.HasSetting(CompactHeader)</selected>
+            </control>
+            <!--set subheader infoline, check use always auto, remove setting, define variable -->
+            <control type="button" id="31688">
+                <include>SkinSettings_Button</include>
+                <label>31688</label>
+                <label2>$INFO[Skin.String(infoline.label)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=infoline,header=$LOCALIZE[31688])</onclick>
+                
+                <visible>String.Contains(Skin.String(general_header),title) | String.Contains(Skin.String(home_header),title)</visible>
+            </control>
+            
+            <!--custom logo-->
+            <control type="radiobutton" id="23023">
+                <include>SkinSettings_Button</include>
+                <label>31337</label>
+                <onclick condition="!Skin.String(CustomLogoImage)">RunScript(script.skin.helper.service,action=SAVESKINIMAGE,skinstring=CustomLogoImage)</onclick>
+                <onclick condition="Skin.String(CustomLogoImage)">Skin.Reset(CustomLogoImage)</onclick>
+                <selected>Skin.String(CustomLogoImage)</selected>
+                <visible>String.Contains(Skin.String(general_header),logo) | String.Contains(Skin.String(home_header),logo) | Skin.String(HomeLayout,netflix2)</visible>
+            </control>
+            <!-- logo alignment-->
+            <control type="button" id="123023">
+                <include>SkinSettings_Button</include>
+                <label>31618</label>
+                <label2>$INFO[Skin.String(LogoImageAlignment)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=LogoImageAlignment,header=$LOCALIZE[31618])</onclick>
+                <visible>String.Contains(Skin.String(home_header),logo) + String.Contains(Skin.String(HomeLayout),simplever)</visible>
+                <visible>Skin.String(CustomLogoImage)</visible>
+            </control>
+            
+            <control type="radiobutton" id="31700">
+                <include>SkinSettings_Button</include>
+                <label>31700</label>
+                <onclick>Skin.ToggleSetting(Home_RecordingIndicator)</onclick>
+                <selected>Skin.HasSetting(Home_RecordingIndicator)</selected>
+            </control>
+            
+            <control type="radiobutton" id="31740">
+                <include>SkinSettings_Button</include>
+                <label>31740</label>
+                <onclick>Skin.ToggleSetting(Home_ShowBackgroundLogo)</onclick>
+                <selected>Skin.HasSetting(Home_ShowBackgroundLogo)</selected>
+                <visible>String.Contains(Skin.String(home_header),logo)</visible>
+            </control>
+            
+            <!-- advanced settings -->
+            <control type="label" id="8010">
+                <include>SkinSettings_Header</include>
+                <label>31270</label>
+                <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+            </control>
+            
+            <control type="button" id="17121">
+                <description>Weather Icons</description>
+                <include>SkinSettings_Button</include>
+                <label>31623</label>
+                <label2>$INFO[Skin.String(WeatherIconPack.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=WeatherIconPack,addontype=resource.images.weathericons)</onclick>
+            </control>
+            
+            <control type="button" id="17117"> <!-- check, double id 17122 old -->
+                <description>Weather FanArt</description>
+                <include>SkinSettings_Button</include>
+                <label>31624</label>
+                <label2>$INFO[Skin.String(WeatherFanArtPack.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=WeatherFanArtPack,addontype=resource.images.weatherfanart)</onclick>
+            </control>
+            
+            <control type="button" id="31625">
+                <description>Studio Icons</description>
+                <include>SkinSettings_Button</include>
+                <label>31625</label>
+                <label2>$INFO[Skin.String(SkinHelper.StudioLogos.Name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=SkinHelper.StudioLogos,addontype=resource.images.studios)</onclick>
+            </control>
+            
+            <control type="button" id="17125">
+                <description>Movie Genre Icons</description>
+                <include>SkinSettings_Button</include>
+                <label>31626</label>
+                <label2>$INFO[Skin.String(MovieGenreIconPack.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=MovieGenreIconPack,addontype=resource.images.moviegenreicons)</onclick>
+            </control>
+            
+            <control type="button" id="17126">
+                <description>Music Genre Icons</description>
+                <include>SkinSettings_Button</include>
+                <label>31627</label>
+                <label2>$INFO[Skin.String(MusicGenreIconPack.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=MusicGenreIconPack,addontype=resource.images.musicgenreicons)</onclick>
+            </control>
+            
+            <control type="button" id="31772">
+                <description>Movie Genre Fanart</description>
+                <include>SkinSettings_Button</include>
+                <label>31772</label>
+                <label2>$INFO[Skin.String(moviegenrefanart.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=moviegenrefanart,addontype=resource.images.moviegenrefanart)</onclick>
+            </control>
+            
+            <control type="button" id="31826">
+                <description>Language Flags</description>
+                <include>SkinSettings_Button</include>
+                <label>31826</label>
+                <label2>$INFO[Skin.String(LanguageFlags.name)]</label2>
+                <onclick>RunScript(script.skin.helper.service,action=setresourceaddon,skinstring=LanguageFlags,addontype=resource.images.languageflags)</onclick>
+            </control>
+            
+            <control type="radiobutton" id="5160">
+                <description>Low performance systems</description>
+                <include>SkinSettings_Button</include>
+                <label>31326</label>
+                <onclick>Skin.ToggleSetting(LowPerformanceMode)</onclick>
+                <onclick>Skin.Reset(SkinHelper.EnableExtraFanart)</onclick>
+                <onclick>Skin.SetString(SkinHelper.ShowInfoAtPlaybackStart,0)</onclick>
+                <selected>Skin.HasSetting(LowPerformanceMode)</selected>
+            </control>
+            <control type="radiobutton" id="8025">
+                <include>SkinSettings_Button</include>
+                <label>31808</label>
+                <onclick>Skin.ToggleSetting(EnableWeatherAlertOverlay)</onclick>
+                <selected>Skin.HasSetting(EnableWeatherAlertOverlay)</selected>
+            </control>
+            <!-- skin helper settings -->
+            <include content="SkinSettings_ActionButton">
+                <param name="id" value="8019" />
+                <param name="label" value="31630" />
+                <param name="action" value="Addon.OpenSettings(script.module.metadatautils)" />
+                <param name="visible" value="true" />
+            </include>
+            <control type="radiobutton" id="8020">
+                <!-- enable splash image or movie -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31631</label>
+                <onclick condition="!Skin.String(SplashScreen)">Skin.SetFile(SplashScreen)</onclick>
+                <onclick condition="Skin.String(SplashScreen)">Skin.Reset(SplashScreen)</onclick>
+                <selected>Skin.String(SplashScreen)</selected>
+            </control>
+            <control type="radiobutton" id="8021">
+                <!-- enable snow on home -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31644</label>
+                <onclick>Skin.ToggleSetting(enablesnow)</onclick>
+                <selected>Skin.HasSetting(enablesnow)</selected>
+            </control>
+            <control type="radiobutton" id="8022">
+                <!-- expand snow effect to other areas of the skin -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>     ----- $LOCALIZE[31645]</label>
+                <onclick>Skin.ToggleSetting(expandsnow)</onclick>
+                <selected>Skin.HasSetting(expandsnow)</selected>
+                <visible>Skin.HasSetting(enablesnow) + !Skin.String(general_header,disable) + !Skin.HasSetting(AlwaysShowWeather)</visible>
+            </control>
+            <control type="radiobutton" id="8023">
+                <!-- prefer clearart over landscapes -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31652</label>
+                <onclick>Skin.ToggleSetting(PreferClearArtOverLandscape)</onclick>
+                <selected>Skin.HasSetting(PreferClearArtOverLandscape)</selected>
+            </control>
+            <control type="radiobutton" id="8024">
+                <!-- dialog yesno default focus to NO -->
+                <description></description>
+                <include>SkinSettings_Button</include>
+                <label>31656</label>
+                <onclick>Skin.ToggleSetting(DialogYesNo_FocusNO)</onclick>
+                <selected>Skin.HasSetting(DialogYesNo_FocusNO)</selected>
+            </control>
+			<!-- may remove -->
+            <control type="radiobutton" id="31710">
+                <description>Enable skin helper artwork lookups for addons</description>
+                <include>SkinSettings_Button</include>
+                <label>31710</label>
+                <onclick>Skin.ToggleSetting(SkinHelper.EnableExtendedArt)</onclick>
+                <selected>Skin.HasSetting(SkinHelper.EnableExtendedArt)</selected>
+            </control>
+            <control type="radiobutton" id="31724">
+                <description>Do not display hour representation of the duration</description>
+                <include>SkinSettings_Button</include>
+                <label>31724</label>
+                <onclick>Skin.ToggleSetting(DisableHoursDuration)</onclick>
+                <selected>Skin.HasSetting(DisableHoursDuration)</selected>
+            </control>
+            <control type="radiobutton" id="31762">
+                <description>Keep widget focused when starting playback from home widget</description>
+                <include>SkinSettings_Button</include>
+                <label>31762</label>
+                <onclick>Skin.ToggleSetting(KeepWidgetFocus)</onclick>
+                <selected>Skin.HasSetting(KeepWidgetFocus)</selected>
+            </control>
+			<!-- check, still valid function ? -->
+            <control type="radiobutton" id="31765">
+                <description>Emby CoverArt compatability</description>
+                <include>SkinSettings_Button</include>
+                <label>31765</label>
+                <onclick>Skin.ToggleSetting(EmbyCovertArtEnabled)</onclick>
+                <selected>Skin.HasSetting(EmbyCovertArtEnabled)</selected>
+            </control>
+			<!-- free id="31766" -->
+			<!-- free id="31796" -->
+        </control>
+
+        <!--scrollbar for general settings-->
+        <control type="scrollbar" id="312"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>5000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),6)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_General_Colors">
+        <!-- general color settings -->
+        <control type="label" id="13010">
+            <include>SkinSettings_Header</include>
+            <label>$LOCALIZE[31486]</label>
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+       
+        <!--buttons color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31475" />
+            <param name="label" value="$LOCALIZE[31475]" />
+            <param name="skinsetting" value="ButtonColor" />
+        </include>
+       <!--buttons focus color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31233" />
+            <param name="label" value="$LOCALIZE[31233]" />
+            <param name="skinsetting" value="ButtonFocusColor" />
+        </include>
+         <!--buttons text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31458" />
+            <param name="label" value="$LOCALIZE[31458]" />
+            <param name="skinsetting" value="ButtonTextColor" />
+        </include>
+         <!--buttons focus text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31459" />
+            <param name="label" value="$LOCALIZE[31459]" />
+            <param name="skinsetting" value="ButtonFocusTextColor" />
+        </include>
+        <!--spincontrol and radiobutton color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31788" />
+            <param name="label" value="$LOCALIZE[31788]" />
+            <param name="skinsetting" value="ActiveSpinControlColor" />
+        </include>
+         <!--General panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31260" />
+            <param name="label" value="$LOCALIZE[31260]" />
+            <param name="skinsetting" value="GeneralPanelsColor" />
+        </include>
+         <!--general text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31460" />
+            <param name="label" value="$LOCALIZE[31460]" />
+            <param name="skinsetting" value="GeneralTextColor" />
+        </include>
+         <!--highlight text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31572" />
+            <param name="label" value="$LOCALIZE[31572]" />
+            <param name="skinsetting" value="GeneralHighlightTextColor" />
+        </include>
+									   
+        <!--scrollbar background color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31495" />
+            <param name="label" value="$LOCALIZE[31495]" />
+            <param name="skinsetting" value="ScrollbarBackgroundColor" />
+        </include>
+         <!--scrollbar unfocused color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31496" />
+            <param name="label" value="$LOCALIZE[31496]" />
+            <param name="skinsetting" value="ScrollbarUnfocusedColor" />
+        </include>
+         <!--scrollbar focused color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31497" />
+            <param name="label" value="$LOCALIZE[31497]" />
+            <param name="skinsetting" value="ScrollbarFocusedColor" />
+        </include>
+         <!--sideblade panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31601" />
+            <param name="label" value="$LOCALIZE[31601]" />
+            <param name="skinsetting" value="SideBladePanelColor" />
+        </include>
+         <!--sideblade text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31602" />
+            <param name="label" value="$LOCALIZE[31602]" />
+            <param name="skinsetting" value="SideBladeTextColor" />
+        </include>
+		<!-- homemenu focused button color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31834" />
+            <param name="label" value=" -- Dialog Frame/BG Color" />
+            <param name="skinsetting" value="DialogFrameColor" />
+        </include>
+         <!--label overlay panel color , Secondary Tag Color?-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31603" />
+            <param name="label" value="$LOCALIZE[31603]" />
+            <param name="skinsetting" value="TagOverlaysPanelColor" />
+        </include>
+        <!--label overlay text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31604" />
+            <param name="label" value="$LOCALIZE[31604]" />
+            <param name="skinsetting" value="TagOverlaysTextColor" />
+        </include>
+        
+		
+		<!-- H O M E M E N U color settings -->
+        <control type="label" id="13080">
+            <include>SkinSettings_Header</include>
+            <label>H O M E M E N U</label> <!-- $LOCALIZE[31121] -->
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+		<!--homemenu panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31742" />
+            <param name="label" value="$LOCALIZE[31742]" />
+            <param name="skinsetting" value="MainMenuPanelColor" />
+            <param name="visible" value="String.Contains(Skin.String(HomeLayout),hor) | String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix) | String.Contains(Skin.String(HomeLayout),win10)" />
+        </include>
+		<!-- Widget_ContainerHeaderText Color text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31229" />
+            <param name="label" value="Widget Header TextColor" />
+            <param name="skinsetting" value="WidgetHeaderTextColor" />
+        </include>
+        <!--homemenu unfocused text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31743" />
+            <param name="label" value="Widget Details/Tiles/$LOCALIZE[31743]" />
+            <param name="skinsetting" value="MainMenuTextColor" />
+            <!-- <param name="visible" value="String.Contains(Skin.String(HomeLayout),hor) | String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix) | String.Contains(Skin.String(HomeLayout),win10)" /> -->
+        </include>
+        <!--homemenu focused text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31744" />
+            <param name="label" value="Widget Details/Tiles/$LOCALIZE[31744]" />
+            <param name="skinsetting" value="MainMenuFocusTextColor" />
+            <!-- <param name="visible" value="String.Contains(Skin.String(HomeLayout),hor) | String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix) | String.Contains(Skin.String(HomeLayout),win10)" /> -->
+        </include>
+		<include content="SkinSettings_ColorButton">
+            <param name="id" value="31943" />
+            <param name="label" value="Widget Details/Tiles/$LOCALIZE[31943]" />
+            <param name="skinsetting" value="WidgetDetailsFocusTextColor" />
+            <!-- <param name="visible" value="String.Contains(Skin.String(HomeLayout),hor) | String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout),netflix) | String.Contains(Skin.String(HomeLayout),win10)" /> -->
+        </include>
+        <!--homemenu secondary focused button color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31835" />
+            <param name="label" value="Bottom Shutdown Menu focused BG (Windows10 and $LOCALIZE[31544])" />
+            <param name="skinsetting" value="MainMenuSecondaryFocusButtonColor" />
+            <param name="visible" value="Skin.String(HomeLayout,netflix2)" />
+        </include>
+		<!-- Widgets Detail Panels and Tiles - Background Color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31174" />
+            <param name="label" value="Widgets Detail Panels and Tiles - Background Color" />
+            <param name="skinsetting" value="HomeViewDetailsFocusColor" />
+        </include>
+		<!-- Widgets and Tiles - focused Border Color -->
+        <include content="SkinSettings_ColorButton"><!-- check the use of var -->
+            <param name="id" value="31829" />
+			<param name="label" value="Widgets and Tiles - focused Border Color" />
+            <param name="skinsetting" value="HomeViewDetailsBorderFocusColor" />
+        </include>
+		<!-- Widgets and Tiles - unfocused Border Color -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31735" />
+			<param name="label" value="Widgets and Tiles - unfocused Border Color" />
+            <param name="skinsetting" value="HomeWidgetsBorderColor" />
+        </include>
+		
+        <!--spotlight button unfocused color=textcolor-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31850" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[31185]-$LOCALIZE[35103] unfocused Color" />
+            <param name="skinsetting" value="HomeSpotlightButtonNoFocusColor" />
+        </include>
+		<!--spotlight button focus bg color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31851" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[31185]-$LOCALIZE[35103] focused bg Color" />
+            <param name="skinsetting" value="HomeSpotlightButtonFocusBGColor" />
+        </include>
+		<!-- spotlight button focused label color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31852" />
+            <param name="label" value="$LOCALIZE[31018] $LOCALIZE[31185]-$LOCALIZE[35103] focused Label Color" />
+            <param name="skinsetting" value="HomeSpotlightButtonFocusLabelColor" />
+        </include>
+		<!-- move thumb colors to depending setting w vis. conds.-->
+		
+		<!-- HEADER color settings -->
+        <control type="label" id="13070">
+            <include>SkinSettings_Header</include>
+            <label>H E A D E R</label> <!-- $LOCALIZE[31486] -->
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+		<!--header panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31791" />
+            <param name="label" value="$LOCALIZE[31791]" />
+            <param name="skinsetting" value="HeaderPanelColor" />
+        </include>
+        <!--header text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31219" />
+            <param name="label" value="$LOCALIZE[31219]" />
+            <param name="skinsetting" value="HeaderTextColor" />
+        </include>
+		 <!--header shadow color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31220" />
+            <param name="label" value="$LOCALIZE[31220]" />
+            <param name="skinsetting" value="HeaderTextShadowColor" />
+        </include>
+		<!--2ndaryheader text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31301" />
+            <param name="label" value="secondary header $LOCALIZE[31219]" />
+            <param name="skinsetting" value="SecondaryHeaderTextColor" />
+        </include>
+		
+		<!-- F O O T E R color settings -->
+        <control type="label" id="13030">
+            <include>SkinSettings_Header</include>
+            <label>F O O T E R</label> 
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+        <!--footer panel color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31471" />
+            <param name="label" value="$LOCALIZE[31471]" />
+            <param name="skinsetting" value="FooterPanelColor" />
+        </include>
+        <!--footer text color (if not netflix) -->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31455" />
+            <param name="label" value="$LOCALIZE[31455]" />
+            <param name="skinsetting" value="FooterTextColor" />
+        </include>
+		<!--footer shadow text color-->
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31477" />
+            <param name="label" value="$LOCALIZE[31477]" />
+            <param name="skinsetting" value="FooterTextShadowColor" />
+        </include>
+    </include>
+    
+    <include name="SkinSettings_Addons">
+        <!-- supported Addons -->
+        <control type="grouplist" id="31000">
+            <description>Control Area</description>
+            <width>100%</width>
+            <height>96%</height>
+            <itemgap>5</itemgap>
+            <onup>31000</onup>
+            <ondown>31000</ondown>
+            <onleft condition="!Window.IsActive(Custom_SkinSettings.xml)">100</onleft>
+            <onleft condition="Window.IsActive(Custom_SkinSettings.xml)">2000</onleft>
+            <onright>3199</onright>
+            <orientation>vertical</orientation>
+            <pagecontrol>3199</pagecontrol>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),31)</visible>
+            <control type="label" id="31696">
+                <include>SkinSettings_Header</include>
+                <label>31696</label>
+            </control>
+
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31030" />
+                <param name="addon" value="script.skin.helper.widgets" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31032" />
+                <param name="addon" value="script.module.metadatautils" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31033" />
+                <param name="addon" value="script.skin.helper.skinbackup" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31002" />
+                <param name="addon" value="script.skinshortcuts" />
+            </include>
+           <!--  <include content="SkinSettings_AddonButton">
+                <param name="id" value="31003" />
+                <param name="addon" value="script.extendedinfo" />
+            </include> -->
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31019" />
+                <param name="addon" value="plugin.program.autocompletion" />
+            </include>
+            <include name="SkinSettings_AddonButton">
+                <param name="id" value="31004" />
+                <param name="addon" value="script.artwork.downloader" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31005" />
+                <param name="addon" value="script.tv.show.next.aired" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31300" />
+                <param name="addon" value="script.artwork.beef" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31052" />
+                <param name="addon" value="script.artwork.downloader" />
+            </include>            
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31007" />
+                <param name="addon" value="service.upnext" />
+            </include>
+			<include content="SkinSettings_AddonButton">
+                <param name="id" value="55143" />
+                <param name="addon" value="plugin.video.netflix" />
+            </include>
+			<include content="SkinSettings_AddonButton">
+                <param name="id" value="55142" />
+                <param name="addon" value="script.user.rating" />
+            </include>
+			<include content="SkinSettings_AddonButton">
+                <param name="id" value="55145" />
+                <param name="addon" value="script.tvmelodies" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31009" />
+                <param name="addon" value="script.cinemavision" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31011" />
+                <param name="addon" value="script.trakt" />
+            </include>
+           <include content="SkinSettings_AddonButton">
+                <param name="id" value="31013" />
+                <param name="addon" value="script.games.rom.collection.browser" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31015" />
+                <param name="addon" value="plugin.video.youtube" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31016" />
+                <param name="addon" value="plugin.video.emby" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31017" />
+                <param name="addon" value="plugin.video.plexbmc" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31020" />
+                <param name="addon" value="resource.images.gamestudios.grayscale" />
+            </include>
+            <include content="SkinSettings_AddonButton">
+                <param name="id" value="31021" />
+                <param name="addon" value="plugin.program.advanced.emulator.launcher" />
+            </include>
+        </control>
+        <control type="scrollbar" id="3199"> 
+            <right>-45</right>
+            <height>96%</height>
+            <onleft>31000</onleft>
+            <showonepage>false</showonepage>
+            <visible>String.IsEqual(Window(Home).Property(SkinSettingSection),31)</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_Button">
+        <width>100%</width>
+        <align>left</align>
+        <height>50</height>
+        <font>arial26</font> <!-- always use arial for the skinsettings because we use some special characters -->
+        <textoffsetx>40</textoffsetx>
+        <textwidth>950</textwidth>
+    </include>
+    
+    <include name="SkinSettings_Header">
+        <width>100%</width>
+        <align>left</align>
+        <height>60</height>
+        <font>Bold36</font>
+        <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+    </include>
+    
+    <include name="SkinSettings_MenuOptions">
+        <!--home menu layout-->
+        <control type="togglebutton" id="12">
+            <label>31115</label>
+            <altlabel>31115</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,12,Home)</onfocus>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),12)</usealttexture>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+        </control>
+        <!--tile settings-->
+        <control type="togglebutton" id="9">
+            <label>31013</label>
+            <altlabel>31013</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,9,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),9)</usealttexture>
+        </control>
+        <!--background settings-->
+        <control type="togglebutton" id="8">
+            <label>31022</label>
+            <altlabel>31022</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,8,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),8)</usealttexture>
+        </control>
+         <control type="togglebutton" id="17">
+            <!--media library-->
+            <label>$LOCALIZE[31221]</label>
+            <altlabel>31221</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,17,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),17)</usealttexture>
+        </control>
+        <control type="togglebutton" id="7">
+            <!--forced views-->
+            <label>$LOCALIZE[31518]</label>
+            <altlabel>31518</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,7,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),7)</usealttexture>
+        </control>
+        <control type="togglebutton" id="16">
+            <!--osd settings-->
+            <label>$LOCALIZE[31668]</label>
+            <altlabel>31668</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,16,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),16)</usealttexture>
+        </control>
+        <control type="togglebutton" id="18">
+            <!--PVR settings-->
+            <label>$LOCALIZE[31088]</label>
+            <altlabel>31088</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,18,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),18)</usealttexture>
+            <visible>PVR.HasTVChannels</visible>
+        </control>
+        <control type="togglebutton" id="6">
+            <!--general-->
+            <label>31005</label>
+            <altlabel>31005</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,6,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),6)</usealttexture>
+        </control>
+        <!-- color themes -->
+        <control type="togglebutton" id="15">
+            <label>31462</label>
+            <altlabel>31462</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,15,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),15)</usealttexture>
+        </control>
+        <!-- custom colors -->
+        <control type="togglebutton" id="20">
+            <label>31667</label>
+            <altlabel>31667</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,20,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),20)</usealttexture>
+        </control>
+        <!-- smart shortcuts -->
+        <control type="togglebutton" id="19">
+            <label>31531</label>
+            <altlabel>31531</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,19,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),19)</usealttexture>
+        </control>
+        <!-- back and restore -->
+        <control type="togglebutton" id="14">
+            <label>31271</label>
+            <altlabel>31271</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,14,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),14)</usealttexture>
+        </control>
+        <control type="togglebutton" id="31">
+            <label>31696</label>
+            <altlabel>31696</altlabel>
+            <onfocus>SetProperty(SkinSettingSection,31,Home)</onfocus>
+            <include condition="!Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonLarge</include>
+            <include condition="Window.IsActive(Custom_SkinSettings.xml)">SkinSettings_MenuButtonSmall</include>
+            <usealttexture>String.IsEqual(Window(Home).Property(SkinSettingSection),31)</usealttexture>
+        </control>
+    </include>
+
+    
+    <include name="SkinSettings_GamePlatformShapes">
+        <!-- Game Thumbs -->
+        <control type="label" id="17170">
+            <include>SkinSettings_Header</include>
+            <label>Game Thumbnails</label>
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+        <control type="button" id="17171">
+            <include>SkinSettings_Button</include>
+            <label>Default Game thumbnail shape</label>
+            <label2>$INFO[Skin.String(game.thumbshape.default.label)]</label2>
+            <onclick>RunScript(script.skin.helper.service,action=setskinsetting,setting=game.thumbshape.default,header=Select preferred thumbnail type)</onclick>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_MenuButtonLarge">
+        <font>Reg28</font>
+        <width>440</width>
+        <align>left</align>
+        <alttexturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="5">diffuse/panel.png</alttexturefocus>
+        <alttexturenofocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="5">diffuse/panel_trans.png</alttexturenofocus>
+    </include>
+    
+    <include name="SkinSettings_MenuButtonSmall">
+        <height>80</height>
+        <width>300</width>
+        <align>center</align>
+        <font>Reg24</font>
+        <textoffsetx>20</textoffsetx>
+        <selectedcolor>$INFO[Skin.String(ButtonFocusTextColor)]</selectedcolor>
+        <textcolor>$INFO[Skin.String(ButtonTextColor)]</textcolor>
+        <focusedcolor>$INFO[Skin.String(ButtonFocusTextColor)]</focusedcolor>
+        <disabledcolor>$INFO[Skin.String(GeneralTextColor)]</disabledcolor>
+        <pulseonselect>false</pulseonselect>
+        <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="20">dialogs/keyboard/key-nf.png</texturefocus>
+        <texturenofocus colordiffuse="$INFO[Skin.String(ButtonColor)]" border="20">dialogs/keyboard/key-nf.png</texturenofocus>
+        <alttexturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="20">dialogs/keyboard/key-nf.png</alttexturefocus>
+        <alttexturenofocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="20">dialogs/keyboard/key-nf.png</alttexturenofocus>
+    </include>
+    
+    <include name="SkinSettings_ActionButton">
+        <control type="radiobutton" id="$PARAM[id]">
+            <include>SkinSettings_Button</include>
+            <textureradiofocus colordiffuse="$INFO[Skin.String(ButtonFocusTextColor)]">common/settings1.png</textureradiofocus>
+            <textureradionofocus colordiffuse="$INFO[Skin.String(ButtonTextColor)]">common/settings1.png</textureradionofocus>
+            <radiowidth>125</radiowidth>
+            <radioheight>40</radioheight>
+            <radioposx>0</radioposx>
+            <radioposy>5</radioposy>
+            <label>$PARAM[label]</label>
+            <onclick>$PARAM[action2]</onclick>
+            <onclick>$PARAM[action]</onclick>
+            <selected>Control.HasFocus($PARAM[id])</selected>
+            <visible>$PARAM[visible]</visible>
+        </control>
+    </include>
+    
+    <include name="SkinSettings_AddonButton">
+        <control type="radiobutton" id="$PARAM[id]">
+            <include>SkinSettings_Button</include>
+            <textureradiofocus colordiffuse="$INFO[Skin.String(ButtonFocusTextColor)]">common/settings1.png</textureradiofocus>
+            <textureradionofocus colordiffuse="$INFO[Skin.String(ButtonTextColor)]">common/settings1.png</textureradionofocus>
+            <radiowidth>125</radiowidth>
+            <radioheight>40</radioheight>
+            <radioposx>0</radioposx>
+            <radioposy>5</radioposy>
+            <include content="SkinSettings_AddonButton_Label" condition="System.HasAddon($PARAM[addon])">
+                <param name="label" value="$INFO[System.AddonTitle($PARAM[addon])] ($INFO[System.AddonVersion($PARAM[addon])])" />
+            </include>
+            <include content="SkinSettings_AddonButton_Label" condition="!System.HasAddon($PARAM[addon])">
+                <param name="label" value="$PARAM[addon]" />
+            </include>
+            <onclick condition="System.HasAddon($PARAM[addon])">Addon.OpenSettings($PARAM[addon])</onclick>
+            <onclick condition="!System.HasAddon($PARAM[addon])">RunPlugin(plugin://$PARAM[addon])</onclick>
+            <selected>Control.HasFocus($PARAM[id])</selected>
+            <animation effect="fade" start="100" end="40" time="0" condition="!System.HasAddon($PARAM[addon])">Conditional</animation>
+        </control>
+    </include>
+    <include name="SkinSettings_AddonButton_Label">
+        <label>$PARAM[label]</label>
+    </include>
+    
+    <include name="SkinSettings_ColorButton">
+        <control type="button" id="$PARAM[id]">
+            <include>SkinSettings_Button</include>
+            <label>$PARAM[labelprefix]$PARAM[label]</label>
+            <label2>$INFO[Skin.String($PARAM[skinsetting].name)]  [COLOR=$INFO[Skin.String($PARAM[skinsetting])]]███[/COLOR]</label2>
+            <onclick condition="System.HasAddon(script.skin.helper.colorpicker)">RunScript(script.skin.helper.colorpicker,action=COLORPICKER,skinstring=$PARAM[skinsetting],header=$PARAM[label],palette=$INFO[Skin.String(defaultcolorpalette)])</onclick>
+            <onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">RunPlugin(plugin://script.skin.helper.colorpicker)</onclick>
+            <visible>$PARAM[visible]</visible>
+        </control>
+    </include>
+    
+</includes>

--- a/extras/‏‏skinsettings.xml
+++ b/extras/‏‏skinsettings.xml
@@ -1,0 +1,573 @@
+<settings>
+    <!-- Titan tiles based homelayouts -->
+    <setting id="HomeLayout" value="1" label="$LOCALIZE[31033]" condition="" icon="special://skin/extras/viewthumbs/homelayout_1.jpg" description="$LOCALIZE[31033][CR][B]Skin default[/B]" default="true">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, tiles)">Skin.Reset(LowerWidgets)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="2" label="$LOCALIZE[31031]" condition="" icon="special://skin/extras/viewthumbs/homelayout_2.jpg" description="$LOCALIZE[31031]">
+        <onselect condition="True">Skin.SetBool(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(LowerWidgets)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="3" label="$LOCALIZE[31032]" condition="" icon="special://skin/extras/viewthumbs/homelayout_3.jpg" description="$LOCALIZE[31032]">
+        <onselect condition="True">Skin.SetBool(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, tiles)">Skin.SetString(SubmenuLayout, horizontal)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, tiles)">Skin.SetString(SubmenuLayout.label,Default)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="1small" label="$LOCALIZE[31649]" condition="" icon="special://skin/extras/viewthumbs/homelayout_1small.jpg" description="$LOCALIZE[31649]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout, horizontal)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout.label,Default)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="2small" label="$LOCALIZE[31650]" condition="" icon="special://skin/extras/viewthumbs/homelayout_2small.jpg" description="$LOCALIZE[31650]">
+        <onselect condition="True">Skin.SetBool(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout, horizontal)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout.label,Default)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(LowerWidgets)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="3small" label="$LOCALIZE[31651]" condition="" icon="special://skin/extras/viewthumbs/homelayout_3small.jpg" description="$LOCALIZE[31651]">
+        <onselect condition="True">Skin.SetBool(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout, horizontal)</onselect>
+		<onselect condition="Skin.String(SubmenuLayout, vertical)">Skin.SetString(SubmenuLayout.label,Default)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    
+    <!-- horizontal home layouts -->
+    <setting id="HomeLayout" value="simplehor" label="$LOCALIZE[31261]" condition="" icon="special://skin/extras/viewthumbs/homelayout_horizontal.jpg" description="$LOCALIZE[31261]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+        <onselect condition="True">Skin.SetBool(UseFixedHomeFocus)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+	<setting id="HomeLayout" value="lowhorizontal" label="$LOCALIZE[31682]" condition="" icon="special://skin/extras/viewthumbs/homelayout_horizontal_low.jpg" description="$LOCALIZE[31682]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,poster)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Poster)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.SetBool(UseFixedHomeFocus)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="lowhorizontal_big" label="$LOCALIZE[31684]" condition="" icon="special://skin/extras/viewthumbs/homelayout_horizontal_low_big.jpg" description="$LOCALIZE[31684]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,poster)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Poster)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.SetBool(UseFixedHomeFocus)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    
+    <!-- vertical homelayouts -->
+    <setting id="HomeLayout" value="simplever" label="$LOCALIZE[31262]" condition="" icon="special://skin/extras/viewthumbs/homelayout_vertical.jpg" description="$LOCALIZE[31262]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,poster)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Poster)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="simplever_tiles" label="$LOCALIZE[31262] (tiles)" condition="" icon="special://skin/extras/viewthumbs/homelayout_vertical_tiles.jpg" description="$LOCALIZE[31262] (tiles)">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,poster)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Poster)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+    </setting>
+    <setting id="HomeLayout" value="verticalbig" label="$LOCALIZE[31686]" condition="" icon="special://skin/extras/viewthumbs/homelayout_verticalbig.jpg" description="$LOCALIZE[31686]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.Reset(VerticalHomeInlineSubmenu)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,poster)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Poster)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+    </setting>
+    
+    <!-- enhanced home -->
+    <setting id="HomeLayout" value="enhanced" label="$LOCALIZE[31183]" condition="!Skin.HasSetting(DisableAllWidgets)" icon="special://skin/extras/viewthumbs/homelayout_enhanced.jpg" description="$LOCALIZE[31183]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(ShowAllWidgets)</onselect>
+    </setting>
+    <!-- netflix home -->
+    <setting id="HomeLayout" value="netflix" label="$LOCALIZE[31544]" condition="" icon="special://skin/extras/viewthumbs/homelayout_netflix.jpg" description="$LOCALIZE[31544]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.SetBool(ShowAllWidgets)</onselect>
+    </setting>
+    <!-- netflix home NEW -->
+    <setting id="HomeLayout" value="netflix2" label="Netflix Origin" condition="" icon="special://skin/extras/viewthumbs/homelayout_netflix2.jpg" description="$LOCALIZE[31544]">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle,landscape)</onselect>
+        <onselect condition="True">Skin.SetString(widgetstyle.label,Landscape)</onselect>
+        <onselect condition="True">Skin.Reset(CompactHeader)</onselect>
+        <onselect condition="True">Skin.Reset(WidgetAlignRight)</onselect>
+        <onselect condition="True">Skin.SetBool(ShowAllWidgets)</onselect>
+    </setting>
+    <!-- win10 home -->
+    <setting id="HomeLayout" value="win10" label="Windows 10" condition="" icon="special://skin/extras/viewthumbs/homelayout_win10.jpg" description="Windows 10">
+        <onselect condition="True">Skin.Reset(OpenSubMenuOnClick)</onselect>
+        <onselect condition="True">Skin.SetBool(CompactHeader)</onselect>
+    </setting>
+    
+    <!-- submenu layout -->
+    <setting id="SubmenuLayout" value="vertical" label="$LOCALIZE[31313]" condition="![Skin.String(HomeLayout,1small) | Skin.String(HomeLayout,2small) | Skin.String(HomeLayout,3small)]" icon="special://skin/extras/viewthumbs/submenulayout_vertical.jpg" description=""/>
+    <setting id="SubmenuLayout" value="horizontal" label="$LOCALIZE[31314]" condition="" icon="special://skin/extras/viewthumbs/submenulayout_horizontal.jpg" description="[B]Default[/B]" default="true"/>
+    <setting id="SubmenuLayout" value="tiles" label="$LOCALIZE[31315]" condition="!Skin.String(HomeLayout,3)" icon="special://skin/extras/viewthumbs/submenulayout_tiles.jpg" description=""/>
+    <setting id="SubmenuLayout" value="subpage" label="$LOCALIZE[31316]" condition="" icon="special://skin/extras/viewthumbs/submenulayout_subpage.jpg" description=""/>
+    
+    
+    <setting id="widgetstyle" value="None" label="$LOCALIZE[31641]" condition="!String.IsEmpty(Window.Property(widgetcontrols)) + !Skin.String(HomeLayout,win10)" icon="DefaultAddonNone.png" description="$INFO[Skin.String(widgetstyle)]"/>
+    
+    <!-- widget style: horizontal -->
+    <setting id="widgetstyle" value="poster" label="Poster" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_poster.jpg" description=""/>
+    <setting id="widgetstyle" value="landscape" label="Landscape" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="landscapesmall" label="Landscape Small" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="singlebox" label="Single Box" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_singlebox.jpg" description=""/>
+    <setting id="widgetstyle" value="square" label="Square" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_square.jpg" description=""/>
+    <setting id="widgetstyle" value="minisquare" label="Mini Square" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_square.jpg" description=""/>
+    <setting id="widgetstyle" value="smallposter" label="Small Posters" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_smallposter.jpg" description=""/>
+    <setting id="widgetstyle" value="widebox" label="Wide Box" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_hor_widebox.jpg" description=""/>
+    <setting id="widgetstyle" value="banner" label="Banner" condition="!String.Contains(Skin.String(HomeLayout),ver) + !Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_win10_banner.jpg" description=""/>
+    
+    <!-- widget style: win10 -->
+    <setting id="widgetstyle" value="square" label="Square" condition="Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_win10_square.jpg" description=""/>
+    <setting id="widgetstyle" value="smallposter" label="Small Posters" condition="Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_win10_poster.jpg" description=""/>
+    <setting id="widgetstyle" value="landscape" label="Landscape" condition="Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_win10_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="banner" label="Banner" condition="Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_win10_banner.jpg" description=""/>
+    
+    <!-- widget style: vertical -->
+    <setting id="widgetstyle" value="poster" label="Poster" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_poster.jpg" description=""/>
+    <setting id="widgetstyle" value="landscape" label="Landscape" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="landscapesmall" label="Landscape Small" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="singlebox" label="Single Box" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_singlebox.jpg" description=""/>
+    <setting id="widgetstyle" value="square" label="Square" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_square.jpg" description=""/>
+    <setting id="widgetstyle" value="minisquare" label="Mini Square" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_square.jpg" description=""/>
+    <setting id="widgetstyle" value="smallposter" label="Small Posters" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_smallposter.jpg" description=""/>
+    <setting id="widgetstyle" value="widebox" label="Wide Box" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_ver_widebox.jpg" description=""/>
+    <setting id="widgetstyle" value="banner" label="Banner" condition="String.Contains(Skin.String(HomeLayout),ver)" icon="special://skin/extras/viewthumbs/widget_win10_banner.jpg" description=""/>
+    
+    <!-- widgetstyle landscape netflix -->
+    <setting id="widgetstyle" value="netflixspotlight" label="Netflix Spotlight" condition="String.Contains(Skin.String(HomeLayout),netflix)" icon="add me" description=""/>
+    <setting id="widgetstyle" value="landscapelarge" label="Landscape Large Netflix" condition="!Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_netflix_landscape.jpg" description=""/>
+    <setting id="widgetstyle" value="landscapedetails" label="Landscape Details" condition="!Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_landscapedetails.jpg" description=""/>
+	<setting id="widgetstyle" value="circle" label="Circle" condition="!Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_circle.jpg" description=""/>
+	<setting id="widgetstyle" value="posterdetails" label="Poster Details" condition="!Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_posterdetails.jpg" description=""/>
+	<setting id="widgetstyle" value="landscapewidedetails" label="Landscape Wide" condition="!Skin.String(HomeLayout,win10)" icon="special://skin/extras/viewthumbs/widget_landscapewidedetails.jpg" description=""/>
+
+	<!-- media flags -->
+    <setting id="mediaflagsstyle" value="classic" label="Classic" condition="" icon="special://skin/extras/viewthumbs/flags_classic.jpg" description="">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="mediaflagsstyle" value="boxed" label="Boxed Info" condition="" icon="special://skin/extras/viewthumbs/flags_boxed.jpg" description="">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+   <setting id="mediaflagsstyle" value="textbased - full info" label="Textbased - Full Info" condition="" icon="special://skin/extras/viewthumbs/flags_text.jpg" description="">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="mediaflagsstyle" value="large" label="Large Icons" condition="" icon="special://skin/extras/viewthumbs/flags_large.jpg" description="">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="mediaflagsstyle" value="large_color" label="Large Icons Color" condition="" icon="special://skin/extras/viewthumbs/flags_large_color.jpg" description="">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="mediaflagsstyle" value="disabled" label="Disabled" condition="" icon="" description="" default="true">
+        <onselect condition="Window.IsActive(MyVideoNav.xml)">ReloadSkin</onselect>
+    </setting>
+    
+    <!-- OSD media flags -->
+    <setting id="osdmediaflagsstyle" value="classic" label="Classic" condition="" icon="special://skin/extras/viewthumbs/flags_classic.jpg" description=""/>
+    <setting id="osdmediaflagsstyle" value="boxed" label="Boxed Info" condition="" icon="special://skin/extras/viewthumbs/flags_boxed.jpg" description=""/>
+    <setting id="osdmediaflagsstyle" value="textbased - full info" label="Textbased - Full Info" condition="" icon="special://skin/extras/viewthumbs/flags_text.jpg" description=""/>
+    <setting id="osdmediaflagsstyle" value="large" label="Large Icons" condition="" icon="special://skin/extras/viewthumbs/flags_large.jpg" description=""/>
+    <setting id="osdmediaflagsstyle" value="large_color" label="Large Icons Color" condition="" icon="special://skin/extras/viewthumbs/flags_large_color.jpg" description=""/>
+    <setting id="osdmediaflagsstyle" value="disabled" label="Disabled" condition="" icon="" description="" default="true"/>
+
+    <!-- Guide rows -->
+    <setting id="GuideRows" value="7" label="7 rows" condition="" icon="special://skin/extras/viewthumbs/guide_7.jpg" description="">
+        <onselect condition="Window.IsActive(MyPVRGuide.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="GuideRows" value="8" label="8 rows" condition="" icon="special://skin/extras/viewthumbs/guide_9.jpg" description="">
+        <onselect condition="Window.IsActive(MyPVRGuide.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="GuideRows" value="9" label="9 rows" condition="" icon="special://skin/extras/viewthumbs/guide_9.jpg" description="" default="true">
+        <onselect condition="Window.IsActive(MyPVRGuide.xml)">ReloadSkin</onselect>
+    </setting>
+    <setting id="GuideRows" value="10" label="10 rows" condition="" icon="special://skin/extras/viewthumbs/guide_10.jpg" description="">
+        <onselect condition="Window.IsActive(MyPVRGuide.xml)">ReloadSkin</onselect>
+    </setting>
+    
+    <!-- Global Background -->
+    <setting id="CustomBackgroundSetting" value="None" label="None" condition="" icon="" description="" default="true"/>
+    <setting id="CustomBackgroundSetting" value="colors/color_transparent.png" label="Transparent" condition="" icon="colors/color_transparent.png" description="Transparent Image"/>
+    <setting id="CustomBackgroundSetting" value="resource://resource.images.skinbackgrounds.titanium/global_blue.jpg" label="$LOCALIZE[31023]" condition="" icon="resource://resource.images.skinbackgrounds.titanium/global_blue.jpg" description="Default Titan background"/>  <!--removed default -->
+    <setting id="CustomBackgroundSetting" value="$INFO[Skin.String(WeatherFanArtPack.path)]$INFO[Window(Weather).Property(Current.fanartCode)]$INFO[Skin.String(WeatherFanArtPack.ext)]" label="$LOCALIZE[31025]" condition="!String.IsEmpty(Window(Weather).Property(current.fanartCode)) + Skin.String(WeatherFanArtPack.path)" icon="$INFO[Skin.String(WeatherFanArtPack.path)]$INFO[Window(Weather).Property(Current.fanartCode)]$INFO[Skin.String(WeatherFanArtPack.ext)]" description=""/>
+
+    <setting id="CustomBackgroundSetting" value="widgetfanart" label="$LOCALIZE[31612]" condition="!String.IsEmpty(Container(211).ListItem.Property(widget))" />
+
+    <!--Auto Trailer Interval-->
+    <setting id="auto_trailer_interval" value="3" label="3 Seconds" condition="" icon="" description=""/>
+    <setting id="auto_trailer_interval" value="5" label="5 Seconds" condition="" icon="" description=""/>
+    <setting id="auto_trailer_interval" value="7" label="7 Seconds" condition="" icon="" description="" default="true"/>
+    <setting id="auto_trailer_interval" value="9" label="9 Seconds" condition="" icon="" description=""/>
+
+    <!--Thumbs Up Rate Value-->
+    <setting id="ThumbsUpRateValue" value="6" label="6" condition="" icon="" description=""/>
+    <setting id="ThumbsUpRateValue" value="7" label="7" condition="" icon="" description=""/>
+    <setting id="ThumbsUpRateValue" value="8" label="8" condition="" icon="" description="" default="true"/>
+    <setting id="ThumbsUpRateValue" value="9" label="9" condition="" icon="" description=""/>
+    <setting id="ThumbsUpRateValue" value="10" label="10" condition="" icon="" description=""/>
+
+    <!--Thumbs Down Rate Value-->
+    <setting id="ThumbsDownRateValue" value="1" label="1" condition="" icon="" description=""/>
+    <setting id="ThumbsDownRateValue" value="2" label="2" condition="" icon="" description=""/>
+    <setting id="ThumbsDownRateValue" value="3" label="3" condition="" icon="" description="" default="true"/>
+    <setting id="ThumbsDownRateValue" value="4" label="4" condition="" icon="" description=""/>
+    <setting id="ThumbsDownRateValue" value="5" label="5" condition="" icon="" description=""/>
+
+    <!--Thumbs Up Min Value-->
+    <setting id="ThumbsUpMin" value="-1" label="Disabled" condition="" icon="" description=""/>																					   
+    <setting id="ThumbsUpMin" value="6" label="6" condition="" icon="" description=""/>
+    <setting id="ThumbsUpMin" value="7" label="7" condition="" icon="" description=""/>
+    <setting id="ThumbsUpMin" value="8" label="8" condition="" icon="" description="" default="true"/>
+    <setting id="ThumbsUpMin" value="9" label="9" condition="" icon="" description=""/>
+    <setting id="ThumbsUpMin" value="10" label="10" condition="" icon="" description=""/>
+
+    <!--Thumbs Down Max Value-->
+    <setting id="ThumbsDownMax" value="-1" label="Disabled" condition="" icon="" description=""/>
+    <setting id="ThumbsDownMax" value="5" label="5" condition="" icon="" description=""/>
+    <setting id="ThumbsDownMax" value="4" label="4" condition="" icon="" description=""/>
+    <setting id="ThumbsDownMax" value="3" label="3" condition="" icon="" description="" default="true"/>
+    <setting id="ThumbsDownMax" value="2" label="2" condition="" icon="" description=""/>
+    <setting id="ThumbsDownMax" value="1" label="1" condition="" icon="" description=""/>
+
+    <!-- Random fanart delay -->
+    <setting id="SkinHelper.RandomFanartDelay" value="5" label="5 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="10" label="10 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="15" label="15 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="20" label="20 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="30" label="30 $LOCALIZE[31231]" condition="" icon="" description="" default="true"/>
+    <setting id="SkinHelper.RandomFanartDelay" value="40" label="40 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="50" label="50 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="SkinHelper.RandomFanartDelay" value="60" label="60 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    
+    <!-- Extra fanart delay -->
+    <setting id="extrafanartdelay" value="5" label="5 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="6" label="6 $LOCALIZE[31231]" condition="" icon="" description="" default="true"/>
+    <setting id="extrafanartdelay" value="8" label="8 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="10" label="10 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="15" label="15 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="20" label="20 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="30" label="30 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="extrafanartdelay" value="60" label="60 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    
+    <!-- win10 home show infopanel -->
+    <setting id="widgetInfoPanel" value="top" label="Top" condition="" icon="special://skin/extras/viewthumbs/widgetinfo_top.jpg" description=""/>
+    <setting id="widgetInfoPanel" value="bottom" label="Bottom" condition="" icon="special://skin/extras/viewthumbs/widgetinfo_bottom.jpg" description=""/>
+    <setting id="widgetInfoPanel" value="large" label="Large" condition="" icon="special://skin/extras/viewthumbs/widgetinfo_large.jpg" description=""/>
+    <setting id="widgetInfoPanel" value="disable" label="$LOCALIZE[1223]" condition="" icon="special://skin/extras/viewthumbs/widgetinfo_disabled.jpg" description=""/>
+    
+    <!-- artist fanart -->
+    <setting id="MusicArtistFanart" value="single" label="Single fanart image" condition="" icon="" description=""/>
+    <setting id="MusicArtistFanart" value="slideshow" label="Extrafanart (slideshow)" condition="" icon="" description="" default="true"/>
+    <setting id="MusicArtistFanart" value="disabled" label="$LOCALIZE[1223]" condition="" icon="" description=""/>
+    
+    <!-- artist logo -->
+    <setting id="MusicArtistLogo" value="disabled" label="$LOCALIZE[1223]" condition="" icon="" description=""/>
+    <setting id="MusicArtistLogo" value="enabled" label="Always visible" condition="" icon="" description="" default="true"/>
+    <setting id="MusicArtistLogo" value="osd" label="Only when OSD active" condition="" icon="" description=""/>
+    
+    <!-- clearlogo location -->
+    <setting id="ClearLogoLocation" value="topleft" label="$LOCALIZE[31329]" condition="" icon="" description=""/>
+    <setting id="ClearLogoLocation" value="topcenter" label="$LOCALIZE[31330]" condition="!Skin.HasSetting(ShowMovieTitleHeader)" icon="" description=""/>
+    <setting id="ClearLogoLocation" value="topright" label="$LOCALIZE[31331]" condition="" icon="" description=""/>
+    <setting id="ClearLogoLocation" value="footer" label="$LOCALIZE[31328]" condition="!skin.hastheme(classic)" icon="" description="" default="true"/>
+    <setting id="ClearLogoLocation" value="disabled" label="$LOCALIZE[1223]" condition="" icon="" description=""/>
+    
+    <!-- default osd button ,check button label ds, leia changes-->
+    <setting id="defaultosdbutton_video" value="203" label="Play/Pause" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description="" default="!Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    <setting id="defaultosdbutton_video" value="204" label="Stop" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="201" label="Previous" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="202" label="Rewind" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="205" label="Fast Forward" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="206" label="Next" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="104" label="Subtitles" condition="" icon="" description="" default="Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    <setting id="defaultosdbutton_video" value="101" label="Audio Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="102" label="Video Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_video" value="214" label="Bookmarks" condition="" icon="" description=""/>
+    
+    <setting id="defaultosdbutton_livetv" value="203" label="Play/Pause" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description="" default="!Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    <setting id="defaultosdbutton_livetv" value="204" label="Stop" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="201" label="Previous" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="202" label="Rewind" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="205" label="Fast Forward" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="206" label="Next" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="10" label="Record" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="101" label="Audio Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="102" label="Video Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="105" label="Teletext" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="806" label="Channel list" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_livetv" value="807" label="Mini guide" condition="" icon="" description="" default="Skin.HasSetting(OSDDisablePlaybackControls)"/>
+	
+	<setting id="defaultosdbutton_musicPVR" value="203" label="Play/Pause" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description="" default="!Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    <setting id="defaultosdbutton_musicPVR" value="204" label="Stop" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="201" label="Previous" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="202" label="Rewind" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="205" label="Fast Forward" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="206" label="Next" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="10" label="Record" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="101" label="Audio Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="102" label="Video Settings" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="105" label="Teletext" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="806" label="Channel list" condition="" icon="" description=""/>
+    <setting id="defaultosdbutton_musicPVR" value="807" label="Mini guide" condition="" icon="" description="" default="Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    
+    <setting id="defaultosdbutton_music" value="203" label="Play/Pause" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description="" default="!Skin.HasSetting(OSDDisablePlaybackControls)"/>
+    <setting id="defaultosdbutton_music" value="204" label="Stop" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_music" value="201" label="Previous" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_music" value="202" label="Rewind" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_music" value="205" label="Fast Forward" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_music" value="206" label="Next" condition="!Skin.HasSetting(OSDDisablePlaybackControls)" icon="" description=""/>
+    <setting id="defaultosdbutton_music" value="500" label="Visualizations" condition="" icon="" description="" default="Skin.HasSetting(OSDDisablePlaybackControls)"/>
+
+    <!-- kodi logo on home location -->
+    <setting id="LogoImageAlignment" value="center" label="center" condition="" icon="" description=""/>
+    <setting id="LogoImageAlignment" value="right" label="right" condition="" icon="" description="" default="true"/>
+    <setting id="LogoImageAlignment" value="left" label="left" condition="" icon="" description=""/>
+    
+    <!-- vertical home widget rows adjust some time later -->
+    <setting id="WidgetRows" value="single2" label="$LOCALIZE[31752]" condition="String.Contains(Skin.String(HomeLayout), ver)" icon="" description="Display 1 widget with multiple rows and widget selection button"/>
+    <setting id="WidgetRows" value="single" label="$LOCALIZE[31751]" condition="!String.Contains(Skin.String(HomeLayout), netflix)" icon="" description="Display 1 widget with single row and widget selection button"/>
+    <setting id="WidgetRows" value="multi" label="$LOCALIZE[31753]" condition="" icon="" description="Display multiple widgets with 1 row per widget"/>
+    <setting id="WidgetRows" value="multi2" label="$LOCALIZE[31754]" condition="String.Contains(Skin.String(HomeLayout),ver) | String.Contains(Skin.String(HomeLayout), netflix)" icon="" description="Display multiple widgets with multiple rows"/>
+    
+    <!-- case overlay fallback -->
+    <setting id="CaseOverlays.Fallback" value="None" label="None" condition="" icon="" description=""/>
+    <setting id="CaseOverlays.Fallback" value="DVD" label="DVD" condition="" icon="" description=""/>
+    <setting id="CaseOverlays.Fallback" value="Bluray" label="Bluray" condition="" icon="" description="" default="true"/>
+    <setting id="CaseOverlays.Fallback" value="HD1080" label="HD1080" condition="" icon="" description=""/>
+    <setting id="CaseOverlays.Fallback" value="Clear" label="Clear" condition="" icon="" description=""/>
+    
+    <!--thumbs border size unfocused-->
+    <setting id="thumbsborder_unfocused" value="0" label="$LOCALIZE[1223]" condition="" icon="" description=""/>
+    <setting id="thumbsborder_unfocused" value="2" label="$LOCALIZE[31729]" condition="" icon="" description="" default="true" />
+    <setting id="thumbsborder_unfocused" value="4" label="$LOCALIZE[31729]" condition="" icon="" description=""/>
+    <setting id="thumbsborder_unfocused" value="6" label="$LOCALIZE[31729]" condition="" icon="" description=""/>
+    
+    <!--thumbs border size focused-->
+    <setting id="thumbsborder_focused" value="0" label="$LOCALIZE[1223]" condition="" icon="" description=""/>
+    <setting id="thumbsborder_focused" value="2" label="$LOCALIZE[31729]" condition="" icon="" description=""/>
+    <setting id="thumbsborder_focused" value="4" label="$LOCALIZE[31729]" condition="" icon="" description="" default="true" />
+    <setting id="thumbsborder_focused" value="6" label="$LOCALIZE[31729]" condition="" icon="" description=""/>
+    
+    <!-- default focus position for home -->
+    <setting id="home.defaultfocus" value="" label="$LOCALIZE[231]" condition="" icon="" description="" default="true"/>
+    <setting id="home.defaultfocus" value="0" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="1" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="2" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="3" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="4" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="5" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="6" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="7" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="8" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="9" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+    <setting id="home.defaultfocus" value="10" label="$LOCALIZE[31728]" condition="" icon="" description=""/>
+
+	<!-- Default Color Palette -->
+    <setting id="defaultcolorpalette" value="basic" label="basic" condition="" icon="special://skin/extras/viewthumbs/defaultcolorpalette_basic.jpg" description=""/>
+    <setting id="defaultcolorpalette" value="rainbow" label="rainbow" condition="" icon="special://skin/extras/viewthumbs/defaultcolorpalette_rainbow.jpg" description="" default="true"/>
+    <setting id="defaultcolorpalette" value="material-design" label="material-design" condition="" icon="special://skin/extras/viewthumbs/defaultcolorpalette_material-design.jpg" description=""/>
+    <setting id="defaultcolorpalette" value="webcolors" label="webcolors" condition="" icon="special://skin/extras/viewthumbs/defaultcolorpalette_webcolors.jpg" description=""/>
+    
+    <!-- Volume Indicator Style -->
+    <setting id="volumestyle" value="modern" label="modern" condition="" icon="special://skin/extras/viewthumbs/volumestyle_modern.jpg" description="" default="true"/>
+    <setting id="volumestyle" value="modern-alt" label="modern (alt)" condition="" icon="special://skin/extras/viewthumbs/volumestyle_modern-alt.jpg" description=""/>
+	<setting id="volumestyle" value="classic" label="classic" condition="" icon="special://skin/extras/viewthumbs/volumestyle_classic.jpg" description=""/>
+	<setting id="volumestyle" value="basic" label="basic" condition="" icon="special://skin/extras/viewthumbs/volumestyle_basic.jpg" description=""/>
+
+    <!--widgets rotate-->
+    <setting id="widgets_rotate" value="disabled" label="$LOCALIZE[1223]" condition="" icon="" description="Do not auto rotate the widgets" default="true"/>
+    <setting id="widgets_rotate" value="spotlight" label="$LOCALIZE[31307]" condition="[Skin.String(HomeLayout, enhanced) | [Skin.String(HomeLayout, netflix) + !Skin.HasSetting(NetflixHomeDisableFirstRow)]]" icon="" description="Only rotate the spotlight widget every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="510" label="$LOCALIZE[31499] 1" condition="" icon="" description="Rotate the first widget (if assigned) every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="520" label="$LOCALIZE[31499] 2" condition="" icon="" description="Rotate the second widget (if assigned) every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="530" label="$LOCALIZE[31499] 3" condition="" icon="" description="Rotate the third widget (if assigned) every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="540" label="$LOCALIZE[31499] 4" condition="" icon="" description="Rotate the fourth widget (if assigned) every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="all" label="$LOCALIZE[31730]" condition="" icon="" description="Rotate all widgets (including spotlight) every $INFO[Skin.String(widgets_rotate_delay)] seconds"/>
+    <setting id="widgets_rotate" value="override" label="$LOCALIZE[31731]" condition="!String.Contains(Skin.String(HomeLayout),netflix)" icon="" description="Use the shortcuts editor to enable rotation for a widget"/>
+    
+    <!-- display tags on widgets -->
+	<setting id="Widgets_DisplayTags" value="disable" label="$LOCALIZE[1223]" condition="" icon="" description="Never show tags on widget" default="true"/>
+    <setting id="Widgets_DisplayTags" value="enable" label="$LOCALIZE[305]" condition="" icon="" description="Always show tags on widget"/>
+    
+    <!-- display info in Poster Row View -->
+    <setting id="View_DisplayInfo" value="disable" label="$LOCALIZE[1223]" condition="" icon="" description="Let skin decide based on content/artwork"/>
+    <setting id="View_DisplayInfo" value="small" label="Small" condition="" icon="" description="Use small info panel"/>
+    <setting id="View_DisplayInfo" value="small_delayed" label="Small (delayed)" condition="" icon="" description="Panel will slide in after 3 seconds of inactivity"/>
+      
+    <!-- pvr genre color type -->
+    <setting id="pvrgenretype" value="genre" label="Genre" condition="" icon="" description="Use Genre for guide listings"/>
+    <setting id="pvrgenretype" value="genretype" label="GenreType" condition="" icon="" description="Use GenreType for guide listings - Kodi default" default="true"/>
+    
+    <!-- widget rotate delay -->
+    <setting id="widgets_rotate_delay" value="5" label="5 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="widgets_rotate_delay" value="10" label="10 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="widgets_rotate_delay" value="15" label="15 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="widgets_rotate_delay" value="20" label="20 $LOCALIZE[31231]" condition="" icon="" description="" default="true"/>
+    <setting id="widgets_rotate_delay" value="30" label="30 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    <setting id="widgets_rotate_delay" value="60" label="60 $LOCALIZE[31231]" condition="" icon="" description=""/>
+    
+    <!-- infoline select -->
+    <setting id="infoline" value="none" label="$LOCALIZE[231] - $LOCALIZE[13305]" condition="[Window.IsActive(script-skinshortcuts.xml) + system.getbool(lookandfeel.enablerssfeeds)]" icon="" description=""/>
+    <setting id="infoline" value="none" label="$LOCALIZE[231]" condition="![Window.IsActive(script-skinshortcuts.xml) + system.getbool(lookandfeel.enablerssfeeds)]" icon="" description=""/>
+    <setting id="infoline" value="auto" label="$LOCALIZE[13416]" condition="!Window.IsActive(script-skinshortcuts.xml)" icon="" description="" default="true"/>
+    <setting id="infoline" value="title" label="$LOCALIZE[369]" condition="!Window.IsActive(script-skinshortcuts.xml)" icon="" description=""/>
+    <setting id="infoline" value="backgroundtitle" label="$LOCALIZE[31739]" condition="Window.IsActive(script-skinshortcuts.xml)" icon="" description=""/>
+    <setting id="infoline" value="library_info" label="$LOCALIZE[20314]" condition="" icon="" description=""/>
+    <setting id="infoline" value="movie_library" label="$LOCALIZE[14022] - $LOCALIZE[20342]" condition="" icon="" description=""/>
+    <setting id="infoline" value="tvshows_library" label="$LOCALIZE[14022] - $LOCALIZE[20343]" condition="" icon="" description=""/>
+    <setting id="infoline" value="music_library" label="$LOCALIZE[14022] - $LOCALIZE[2]" condition="" icon="" description=""/>
+    <setting id="infoline" value="pvr" label="$LOCALIZE[19166]" condition="" icon="" description=""/>
+    <setting id="infoline" value="weather" label="$LOCALIZE[24027]" condition="" icon="" description=""/>
+    <setting id="infoline" value="musicvideo_library" label="$LOCALIZE[14022] - $LOCALIZE[20389]" condition="" icon="" description=""/>
+    <setting id="infoline" value="sysinfo" label="$LOCALIZE[130]" condition="" icon="" description=""/>
+    <setting id="infoline" value="addonsinfo" label="$LOCALIZE[24001]/$LOCALIZE[1036]" condition="" icon="" description=""/>
+    <setting id="infoline" value="totalsortby" label="$LOCALIZE[31034]/$LOCALIZE[581]" condition="!Window.IsActive(script-skinshortcuts.xml)" icon="" description=""/>
+    <setting id="infoline" value="total" label="$LOCALIZE[31034]" condition="!Window.IsActive(script-skinshortcuts.xml)" icon="" description=""/>
+    
+    <!-- cast select action in videoinfo -->
+     <!-- <setting id="videoinfo_castaction" value="global_search" label="Global Search Addon" condition="" icon="" description="Search via Global Search (Addon)"/> 
+	cant set searchstring-->
+	
+	<setting id="videoinfo_castaction" value="library_search" label="Library Search" condition="" icon="" description="Search via Titan MOD Search (recommended)" default="true"/>
+    <setting id="videoinfo_castaction" value="embuaryinfo" label="Embuary Info" condition="" icon="" description="Lookup in Embuary Info Addon (recommended)"/>
+	<setting id="videoinfo_castaction" value="extendedinfo" label="$LOCALIZE[31691]" condition="" icon="" description="Lookup in Extended Video Info Addon"/>
+	
+	<!-- options to show in videoinfo - multiselect -->
+    <setting id="videoinfo_buttons" value="||MULTISELECT||" label="" condition="" icon="" description="">
+        <option id="videoinfo_button_play" label="$LOCALIZE[208]" condition="" default="true"/>
+        <option id="videoinfo_button_trailer" label="$LOCALIZE[20410]" condition="" default="true"/>
+        <option id="videoinfo_button_youtubevideos" label="$LOCALIZE[31797]" condition="" default="true"/>
+        <option id="videoinfo_button_cast" label="$LOCALIZE[206]" condition="" default="true"/>
+        <option id="videoinfo_button_similar" label="$LOCALIZE[31622]" condition="" default="true"/>
+        <option id="videoinfo_button_plot" label="$LOCALIZE[207]" condition="" default="true"/>
+        <option id="videoinfo_button_extendedinfo" label="$LOCALIZE[31269]" condition="" default="true"/>
+        <option id="videoinfo_button_cinemavision" label="CinemaVision" condition="System.HasAddon(script.cinemavision)" default=""/>
+        <option id="videoinfo_button_cinemaexperience" label="$INFO[System.AddonTitle(script.cinema.experience)]" condition="System.HasAddon(script.cinema.experience)" default=""/>
+        <option id="videoinfo_button_artworkbeef" label="$LOCALIZE[31300]" condition="System.HasAddon(script.artwork.beef)" default="true"/>
+        <option id="videoinfo_button_artworkdownloader" label="$LOCALIZE[31052]" condition="System.HasAddon(script.artwork.downloader)" default="true"/>
+        <option id="videoinfo_button_artwork" label="$LOCALIZE[13511]" condition="" default="true"/>
+        <option id="videoinfo_button_refresh" label="$LOCALIZE[184]" condition="" default="true"/>
+        <option id="videoinfo_button_discart" label="$LOCALIZE[31200]" condition="" default="true"/>
+        <option id="videoinfo_button_panel" label="$LOCALIZE[31155]" condition="" default="true"/>
+        <option id="videoinfo_button_myrating" label="My Rating" condition="" default="true"/>
+    </setting>
+    <!-- options to show in videoinfo containers - multiselect -->
+    <setting id="videoinfo_containers" value="||MULTISELECT||" label="" condition="" icon="" description="">
+        <option id="videoinfo_container_moviesbasedoncastcontent" label="castcontent" condition="" default="true"/>
+        <option id="videoinfo_container_similiarcontent" label="similiarcontent" condition="" default="true"/>
+        <option id="videoinfo_container_youtubecontent" label="youtubevideos" condition="" default="true"/>
+        <option id="videoinfo_container_localartconent" label="localart" condition="" default="true"/>
+        <option id="videoinfo_container_extrascontent" label="extras" condition="" default="true"/>
+        <option id="videoinfo_container_directorcontent" label="directorcontent" condition="" default="true"/>
+    </setting>
+	
+	<!-- UpNext Layout Simple style -->
+    <setting id="upnext_simple" value="upn_simple_skindefault" label="Skin default" condition="" icon="special://skin/extras/upnext/next_simple_skindefault.jpg" description="" default="true"/>
+    <setting id="upnext_simple" value="upn_simple_addondefault" label="Addon Default" condition="" icon="special://skin/extras/upnext/next_simple_addondefault.jpg" description=""/>
+	<setting id="upnext_simple" value="upn_simple_button" label="Just Button" condition="" icon="special://skin/extras/upnext/next_simple_custom.jpg" description=""/>
+	
+	<!-- UpNext Layout Fancy style -->
+	<setting id="upnext_fancy" value="upn_fancy_netflix" label="Netflix" condition="" icon="special://skin/extras/upnext/next_fancy_netflix.jpg" description="" default="true"/>
+    <setting id="upnext_fancy" value="upn_fancy_def" label="Addon Default" condition="" icon="special://skin/extras/upnext/next_fancy_addondefault.jpg" description=""/>
+	<setting id="upnext_fancy" value="upn_fancy_triangle" label="Triangle" condition="" icon="special://skin/extras/upnext/next_fancy_custom.jpg" description=""/>
+	 
+    <!-- osd button style -->
+    <setting id="osd_buttonstyle" value="rounded" label="$LOCALIZE[31493]" condition="" icon="special://skin/extras/images/button_round.jpg" description=""/>
+    <setting id="osd_buttonstyle" value="slim" label="$LOCALIZE[31697]" condition="" icon="special://skin/extras/images/button_slim.jpg" description="" default="true"/>
+
+    <!-- general header options -->
+    <setting id="general_header" value="disable" label="$LOCALIZE[1223]" condition="" icon="" description="Completely disable the header" default="Skin.HasSetting(DisableHeader)">
+        <onselect condition="Skin.HasSetting(DisableHeader)">Skin.Reset(DisableHeader)</onselect>
+    </setting>
+    <setting id="general_header" value="logo-time" label="$LOCALIZE[31058] + $LOCALIZE[31705]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)]" icon="" description="Show logo (left) and time (right)"/>
+    <setting id="general_header" value="title-time" label="$LOCALIZE[369] + $LOCALIZE[31705]" condition="" icon="" description="Show header title (left) and time (right)" default="!Skin.HasSetting(AlwaysShowWeather) + !Skin.HasSetting(DisableHeader)"/>
+    <setting id="general_header" value="weather-time" label="$LOCALIZE[400] + $LOCALIZE[31705]" condition="!Skin.HasSetting(CompactHeader)" icon="" description="Show weather (left) and time (right)"/>
+    <setting id="general_header" value="title-weather" label="$LOCALIZE[369] + $LOCALIZE[400]" condition="" icon="" description="Show header Title (left) and Weather (right)" default="Skin.HasSetting(AlwaysShowWeather)">
+        <onselect condition="Skin.HasSetting(AlwaysShowWeather)">Skin.Reset(AlwaysShowWeather)</onselect>
+    </setting>
+    <setting id="general_header" value="logo-weathclock" label="$LOCALIZE[31058] + $LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)]" icon="" description="Show logo (left) and time + weather (right)" default=""/>
+    <setting id="general_header" value="title-weathclock" label="$LOCALIZE[369] + $LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,verticalbig)" icon="" description="Show title (left) and time + weather (right)" default=""/>   
+    <setting id="general_header" value="-weathclock" label="$LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)]" icon="" description="Show time + weather (right)" default=""/>
+    <setting id="general_header" value="time" label="$LOCALIZE[31705]" condition="" icon="" description="Only show time"/>
+    <setting id="general_header" value="title" label="$LOCALIZE[369]" condition="" icon="" description="Only show title"/>
+    <setting id="general_header" value="-weather" label="$LOCALIZE[400]" condition="" icon="" description="Only show weather"/>
+    
+    <!-- home header options -->
+	<setting id="home_header" value="disable" label="$LOCALIZE[1223]" condition="" icon="" description="Completely disable the header" />
+    <setting id="home_header" value="logo-time" label="$LOCALIZE[31058] + $LOCALIZE[31705]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,netflix2)" icon="" description="Show logo (left) and time (right)" default="!Skin.HasSetting(WeatherOnHome) + !Skin.String(HomeLayout,win10) + !Skin.String(HomeLayout,netflix2)"/>
+    <setting id="home_header" value="logo-slideweather-time" label="$LOCALIZE[31058] + $LOCALIZE[400] + $LOCALIZE[31705]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,verticalbig) + !Skin.String(HomeLayout,netflix2)" icon="" description="Show logo + weather (left) and time (right)" default="!Skin.String(HomeLayout,win10) + !Skin.String(HomeLayout,netflix2) + !Skin.HasSetting(WeatherOnHome)"/>
+    <setting id="home_header" value="logo-weathclock" label="$LOCALIZE[31058] + $LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,netflix2)" icon="" description="Show logo (left) and time + weather (right)" default=""/>
+    <setting id="home_header" value="-weathclock" label="$LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10)" icon="" description="Show time + weather (right)" default=""/>
+    <setting id="home_header" value="logo-profile" label="$LOCALIZE[31058] + $LOCALIZE[31134]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,netflix2)" icon="" description="Show logo (left) and profile (right)"/>
+    <setting id="home_header" value="logo-weather" label="$LOCALIZE[31058] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10)] + !Skin.String(HomeLayout,netflix2)" icon="" description="Show logo (left) and weather (right)"/>
+    <setting id="home_header" value="title-time" label="$LOCALIZE[369] + $LOCALIZE[31705]" condition="!Skin.String(HomeLayout,netflix2)" icon="" description="Show header title (left) and time (right)"/>
+    <setting id="home_header" value="title-weathclock" label="$LOCALIZE[369] + $LOCALIZE[31705] + $LOCALIZE[400]" condition="![Skin.HasSetting(CompactHeader) + Skin.HasSetting(EnableTouchSupport)] + !Skin.HomeLayout(win10) + !Skin.String(HomeLayout,netflix2)" icon="" description="Show title (left) and time + weather (right)" default=""/>
+    <setting id="home_header" value="weather-time" label="$LOCALIZE[400] + $LOCALIZE[31705]" condition="!Skin.HasSetting(CompactHeader)" icon="" description="Show weather (left) and time (right)" default="!Skin.String(HomeLayout,win10) + Skin.HasSetting(WeatherOnHome) + !Skin.HasSetting(ShowProfile)"/>
+    <setting id="home_header" value="profile-time" label="$LOCALIZE[31134] + $LOCALIZE[31705]" condition="!String.Contains(Skin.String(HomeLayout),netflix2) + !Skin.String(HomeLayout,win10)" icon="" description="Show profile (left) and time (right)" default=""/>
+    <setting id="home_header" value="title-weather" label="$LOCALIZE[369] + $LOCALIZE[400]" condition="!Skin.String(HomeLayout,netflix2)" icon="" description="Show header Title (left) and Weather (right)"/>
+    <setting id="home_header" value="time" label="$LOCALIZE[31705]" condition="" icon="" description="Only show time"/>
+    <setting id="home_header" value="logo" label="$LOCALIZE[31058]" condition="!Skin.String(HomeLayout,netflix2)" icon="" description="Only show logo"/>
+    <setting id="home_header" value="weather-" label="$LOCALIZE[400]" condition="" icon="" description="Only show weather left" default=""/>
+    <setting id="home_header" value="title" label="$LOCALIZE[369]" condition="!Skin.String(HomeLayout,netflix2)" icon="" description="Only show title"/>
+    <setting id="home_header" value="-weather" label="$LOCALIZE[400]" condition="" icon="" description="Only show weather right" default="Skin.HomeLayout(win10)"/>
+    <setting id="home_header" value="-profile" label="$LOCALIZE[31134]" icon="" condition="!Skin.String(HomeLayout,netflix2)" description="Only show profile"/>
+    <!-- vertical home tiles heigth -->
+    <setting id="verthome_tiles_height" value="170" label="Default (170)" icon="" condition="" description="" constantdefault="true"/>
+    <setting id="verthome_tiles_height" value="||PROMPTNUMERIC||" label="Custom value" icon="" condition="" description="Set a custom heigth for the menu tiles. Note that the width is set to 370px and the border/spacing is 8px"/>
+    
+    <!-- custom header for submenu -->
+    <setting id="customsubmenuheader" value="None" label="None" icon="" condition="" description=""/>
+    <setting id="customsubmenuheader" value="" label="$LOCALIZE[1034] (Default)" icon="" condition="" description=""/>
+    <setting id="customsubmenuheader" value="mainmenu" label="Mainmenu title" icon="" condition="" description=""/>
+    <setting id="customsubmenuheader" value="||PROMPTSTRING||" label="Custom header" icon="" condition="" description=""/>  
+    <!-- skinshortcuts background -->
+    <setting id="skinshortcuts-$INFO[Container(211).ListItem.Property(submenuVisibility)]" label="$LOCALIZE[31804]" value="widgetfanart" condition="!String.IsEmpty(Container(211).ListItem.Property(widget))"/>  
+    <setting id="MusicBackground" value="resource://resource.images.skinbackgrounds.titanium/hover_my radio.jpg" label="Default" condition="" default="true" />   
+        
+    <!-- Game thumbnail options -->
+    <setting id="game.thumbshape.default" value="auto" default="true" label="Automatic shape" condition="" icon="" description="Automatically apply default type of thumbnail"/>
+    <setting id="game.thumbshape.default" value="||SUBLEVEL||game.thumbshapes" label="Custom shape" condition="" icon="" description="Choose the desired type of thumbnail"/>
+	
+    <setting id="game.thumbshapes" value="poster" label="Poster" condition="" icon="" description="Apply poster type of thumbnail"/>
+    <setting id="game.thumbshapes" value="bluray" label="Blu-ray" condition="" icon="" description="Apply Blu-ray type of thumbnail"/>
+    <setting id="game.thumbshapes" value="dvd" label="DVD" condition="" icon="" description="Apply DVD type of thumbnail"/>
+    <setting id="game.thumbshapes" value="cd" label="CD" condition="" icon="" description="Apply CD type of thumbnail"/>
+    <setting id="game.thumbshapes" value="widebox" label="Wide box" condition="" icon="" description="Apply wide box type of thumbnail"/>
+    <setting id="game.thumbshapes" value="slimbox" label="Slim poster" condition="" icon="" description="Apply slim poster type of thumbnail"/>
+    <setting id="game.thumbshapes" value="squarebox" label="Square" condition="" icon="" description="Apply square type of thumbnail"/>
+    <setting id="game.thumbshapes" value="3dsbox" label="NDS box" condition="" icon="" description="Apply NDS/3DS box type of thumbnail"/>
+    <setting id="game.thumbshapes" value="steambanner" label="Steam banner" condition="" icon="" description="Apply steam banner type of thumbnail"/>
+    <setting id="game.thumbshapes" value="screenshot" label="Screenshot" condition="" icon="" description="Apply screenshot type of thumbnail"/>
+ 
+</settings>


### PR DESCRIPTION
Hi, @Fuchs246

Regarding Artwork Downloader / Artwork Beef.

I made the old Artwork Downloader addon back to life with Matrix supported and some code fixes (Personally, I prefer this than Beef in the DialogVideoInfo.xml screen)
In order to be able to use it again, I made a modification on these skin files:
- 1080i / ‏‏‏‏IncludesSkinSetings.xml, ‏‏‏‏IncludesDialogVideoInfo.xml, ‏‏‏‏IncludesDialogMusicInfo.xml
- extras / ‏‏skinsettings.xml

Can you add this officialy to your skin version?

It works perfectly.
Screenshots:
https://i.postimg.cc/Vd7hB8Vq/a1.png
https://i.postimg.cc/LJw0wVRh/a2.png
https://i.postimg.cc/Q9k4BG7W/a3.png
https://i.postimg.cc/8FvnSrP4/a4.png

---
Artwork Downloader 15.5.0.0 (Matrix) (Made by me) :
zip: https://f2h.io/orl5efswxyia​​​​​​​

Beef (Matrix) :
zip: https://henryjfry.github.io/repository.thenewdiamond/zips/script.artwork.beef/script.artwork.beef-0.28.6.zip

---

Thanks.