### PR TITLE
Add new colors settings for Main Settings window

### DIFF
--- a/1080i/IncludesDefaultSkinSettings.xml
+++ b/1080i/IncludesDefaultSkinSettings.xml
@@ -295,6 +295,17 @@
         <onload condition="!Skin.String(PVRGuideItemTextColorUnfocus.name)">Skin.SetString(PVRGuideItemTextColorUnfocus.name,$INFO[Skin.String(ButtonTextColor.name)])</onload>
         <onload condition="!Skin.String(PVRGuideItemTextColorFocus)">Skin.SetString(PVRGuideItemTextColorFocus,$INFO[Skin.String(ButtonFocusTextColor)])</onload>
         <onload condition="!Skin.String(PVRGuideItemTextColorFocus.name)">Skin.SetString(PVRGuideItemTextColorFocus.name,$INFO[Skin.String(ButtonFocusTextColor.name)])</onload>
+		<!-- Main Settings colors -->
+		<onload condition="!Skin.String(MainSettingsListItemColorFocus)">Skin.SetString(MainSettingsListItemColorFocus,ffffffe3)</onload>
+        <onload condition="!Skin.String(MainSettingsListItemColorFocus.name)">Skin.SetString(MainSettingsListItemColorFocus.name,default)</onload>
+		<onload condition="!Skin.String(MainSettingsListItemColorNoFocus)">Skin.SetString(MainSettingsListItemColorNoFocus,ffffffff)</onload>
+        <onload condition="!Skin.String(MainSettingsListItemColorNoFocus.name)">Skin.SetString(MainSettingsListItemColorNoFocus.name,white)</onload>
+		<onload condition="!Skin.String(MainSettingsListItemBorderColorFocus)">Skin.SetString(MainSettingsListItemBorderColorFocus,ff00b8ff)</onload>
+        <onload condition="!Skin.String(MainSettingsListItemBorderColorFocus.name)">Skin.SetString(MainSettingsListItemBorderColorFocus.name,mainblue)</onload>
+        <onload condition="!Skin.String(MainSettingsListItemBorderColorNoFocus)">Skin.SetString(MainSettingsListItemBorderColorNoFocus,ff242424)</onload>
+        <onload condition="!Skin.String(MainSettingsListItemBorderColorNoFocus.name)">Skin.SetString(MainSettingsListItemBorderColorNoFocus.name,default)</onload>
+        <onload condition="!Skin.String(MainSettingsInfoPanelColorText)">Skin.SetString(MainSettingsInfoPanelColorText,ffffffe3)</onload>
+        <onload condition="!Skin.String(MainSettingsInfoPanelColorText.name)">Skin.SetString(MainSettingsInfoPanelColorText.name,default)</onload>
 		<!-- UpNext -->
 		<onload condition="!Skin.String(upnext_panel)">Skin.SetString(upnext_panel, cc000000)</onload>
         <onload condition="!Skin.String(upnext_panel.name)">Skin.SetString(upnext_panel.name, default)</onload>

--- a/1080i/IncludesSkinSetings.xml
+++ b/1080i/IncludesSkinSetings.xml
@@ -2446,6 +2446,41 @@
 
     </include>
     
+    <include name="SkinSettings_MainSettings_Colors">    
+        <!-- Main Settings colors -->       
+        <control type="label" id="69569">
+            <include>SkinSettings_Header</include>
+            <label>Main Settings</label> 
+            <textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+        </control>
+        
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31781" />
+            <param name="label" value="Listitem Color (Focus)" />
+            <param name="skinsetting" value="MainSettingsListItemColorFocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31782" />
+            <param name="label" value="Listitem Color (No Focus)" />
+            <param name="skinsetting" value="MainSettingsListItemColorNoFocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31783" />
+            <param name="label" value="Listitem Border Color (Focus)" />
+            <param name="skinsetting" value="MainSettingsListItemBorderColorFocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31784" />
+            <param name="label" value="Listitem Border Color (No Focus)" />
+            <param name="skinsetting" value="MainSettingsListItemBorderColorNoFocus" />
+        </include>
+        <include content="SkinSettings_ColorButton">
+            <param name="id" value="31785" />
+            <param name="label" value="Info Panel Text Color" />
+            <param name="skinsetting" value="MainSettingsInfoPanelColorText" />
+        </include>
+    </include>    
+    
     <include name="SkinSettings_Shortcuts">
         <!-- configure menu -->
         <control type="grouplist" id="6000">
@@ -2655,6 +2690,7 @@
             <include>SkinSettings_General_Colors</include>
             <include>SkinSettings_OSD_Colors</include>
             <include>SkinSettings_Library_Colors</include>
+            <include>SkinSettings_MainSettings_Colors</include>           
             <include condition="PVR.HasTVChannels">SkinSettings_PVR_Colors</include>
      
         </control>

--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -20,20 +20,18 @@
             <bottom>118</bottom>
             <height>75%</height>
             
-			<!--Panel-->
-			<control type="image">
+            <!--Panel-->
+            <control type="image">
                 <width>100%</width>
-				
                 <texture border="15">diffuse/bgpanel.png</texture>
-				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+                <colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
             </control>
             
-			<control type="image">
+            <control type="image">
                 <width>30%</width>
-				
                 <texture border="15">diffuse/bgpanel.png</texture>
-				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
-            </control>            
+                <colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+            </control>
            
             <!--Picture	(Fanart)-->
             <control type="image">

--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -27,10 +27,17 @@
                 <texture border="15">diffuse/bgpanel.png</texture>
 				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
             </control>
+            
+			<control type="image">
+                <width>30%</width>
+				
+                <texture border="15">diffuse/bgpanel.png</texture>
+				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+            </control>            
            
             <!--Picture	(Fanart)-->
             <control type="image">
-                <posx>80</posx>
+                <posx>35</posx>
                 <posy>140</posy>
                 <width>500</width>
                 <height>300</height>
@@ -40,21 +47,21 @@
             
             <!--InfoText-->
             <control type="textbox">
-                <posx>80</posx>
+                <posx>35</posx>
                 <posy>470</posy>
                 <width>500</width>
                 <height>250</height>
                 <font>Reg30</font>
                 <align>center</align>
                 <label>$INFO[Container(9000).ListItem.Label2]</label>
-				<textcolor>$INFO[Skin.String(ViewDetailsListItemTextFocusColor)]</textcolor>
+				<textcolor>$INFO[Skin.String(MainSettingsInfoPanelColorText)]</textcolor>
             </control>
             
 			<!--List 9000-->
             <control type="panel" id="9000">
                 <viewtype label="31437">icons</viewtype>
-                <right>80</right>
-                <top>10</top>
+                <right>20</right>
+                <top>20</top>
                 <height>810</height>
                 <width>1200</width>
                 <orientation>vertical</orientation>
@@ -68,13 +75,13 @@
                         <height>200</height>
 						<control type="image">
 							<texture border="0">diffuse/roundmask.png</texture>
-							<colordiffuse>$VAR[ViewDetailsPanelColor]</colordiffuse>
+							<colordiffuse>$INFO[Skin.String(MainSettingsListItemBorderColorNoFocus)]</colordiffuse>
 						</control>
 						<control type="image">
 							<description>Normal Poster thumb stretched aspect</description>
 							<texture border="1" background="true" diffuse="diffuse/roundmask.png" fallback="DefaultVideo.png">$INFO[ListItem.Icon]</texture>
 							<aspectratio scalediffuse="false" align="center">scale</aspectratio>
-							<colordiffuse>$INFO[Skin.String(ViewDetailsListItemTextColor)]</colordiffuse>
+							<colordiffuse>$INFO[Skin.String(MainSettingsListItemColorNoFocus)]</colordiffuse>
 							<bordersize>17</bordersize>
 						</control>
 					</control>
@@ -86,7 +93,7 @@
 						<label>$INFO[ListItem.Label]</label>
 						<font>Reg22</font>
 						<autoscroll delay="3000" time="3000" repeat="500">false</autoscroll>
-						<textcolor>$INFO[Skin.String(ViewDetailsListItemTextColor)]</textcolor>
+						<textcolor>$INFO[Skin.String(MainSettingsListItemColorNoFocus)]</textcolor>
 					</control>
 					
                 </itemlayout>
@@ -97,12 +104,12 @@
                         <height>200</height>
 						<control type="image">
 							<texture border="0">diffuse/roundmask.png</texture>
-							<colordiffuse>$VAR[ViewDetailsBorderFocusColor]</colordiffuse>
+							<colordiffuse>$INFO[Skin.String(MainSettingsListItemBorderColorFocus)]</colordiffuse>
 							<aspect>keep</aspect>
 						</control>
 						<control type="image">
 							<!-- <animation effect="fade" start="100" end="60" time="250" condition="true">focus</animation> -->
-							<texture border="1" colordiffuse="$INFO[Skin.String(ViewDetailsListItemTextFocusColor)]" background="true" diffuse="diffuse/roundmask.png">$INFO[ListItem.Icon]</texture>
+							<texture border="1" colordiffuse="$INFO[Skin.String(MainSettingsListItemColorFocus)]" background="true" diffuse="diffuse/roundmask.png">$INFO[ListItem.Icon]</texture>
 							<aspectratio scalediffuse="false" aligny="bottom" align="center">scale</aspectratio>
 							<bordersize>15</bordersize>
 						</control>
@@ -114,7 +121,7 @@
 							<label>$INFO[ListItem.Label]</label>
 							<font>Reg22</font>
 							<autoscroll delay="3000" time="3000" repeat="500">false</autoscroll>
-							<textcolor>$INFO[Skin.String(ViewDetailsListItemTextFocusColor)]</textcolor>
+							<textcolor>$INFO[Skin.String(MainSettingsListItemColorFocus)]</textcolor>
 						</control>
 					</control>
 				</focusedlayout>


### PR DESCRIPTION
Add new colors settings for Main Settings window

Since there was some a little conflict between settings colors for Media Listitems and Main Settings,
I decided to create seperate color settings for Main Settings window to make it more clear.

The new color settings are:
- Listitem color (Icon & Label) - Focus* 
- Listitem color (Icon & Label) - No Focus
- Listitem border color - Focus
- Listitem border color - No Focus
- Info text color

In addition I made some little fixes with the total design (such as info panel design and some dimensions)

Screenshot: (After)
https://i.postimg.cc/WpwSGXWJ/Fix-Main-Settings.png